### PR TITLE
Validate bundle against IPS

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,7 @@ Naming/MethodName:
 Metrics/MethodLength:
   Exclude:
     - "lib/au_ps_inferno/utils/basic_test/composition_section_check_resources_ms_elements_module.rb"
+
+Layout/LineLength:
+  Exclude:
+    - "lib/au_ps_inferno/generator/suite_structure/definitions.rb"

--- a/lib/au_ps_inferno/generator/generator.rb
+++ b/lib/au_ps_inferno/generator/generator.rb
@@ -47,6 +47,9 @@ class Generator
   # See SuiteStructure and TestConfigRegistry for adding new groups or test types.
   HIGH_ORDER_GROUPS = SuiteStructure.expand_high_order_groups.freeze
 
+  # Primitive tests expanded from SuiteStructure placeholders for AU PS vs IPS bundle validation.
+  BUNDLE_VALID_TEST_TYPE_IDS = %i[bundle_valid bundle_valid_ips].freeze
+
   # Constructs a new Generator.
   #
   # @param ig_path [String]
@@ -167,7 +170,7 @@ class Generator
   # rubocop:enable Metrics/MethodLength
 
   def validate_primitive_test_type!(test_type_id)
-    return if test_type_id == :bundle_valid
+    return if BUNDLE_VALID_TEST_TYPE_IDS.include?(test_type_id)
     return if TestConfigRegistry.registered?(test_type_id)
 
     raise "Unknown test type id: #{test_type_id.inspect}. Add it to TestConfigRegistry."
@@ -176,16 +179,16 @@ class Generator
   def resolve_primitive_test_labels(test, test_type_id)
     title = test[:title]
     description = test[:description]
-    return [title, description] if test_type_id == :bundle_valid
+    return [title, description] if BUNDLE_VALID_TEST_TYPE_IDS.include?(test_type_id)
 
     registry_config = TestConfigRegistry.config_for(test_type_id, @metadata)
     [title || registry_config[:title], description || registry_config[:description]]
   end
 
   def ensure_bundle_valid_has_title!(test_type_id, resolved_title)
-    return unless test_type_id == :bundle_valid && resolved_title.nil?
+    return unless BUNDLE_VALID_TEST_TYPE_IDS.include?(test_type_id) && resolved_title.nil?
 
-    raise 'Bundle validation test requires bundle_validation_title in high-order config.'
+    raise 'Bundle validation test requires bundle_validation_title / bundle_validation_ips_title in high-order config.'
   end
 
   def primitive_test_fallback_description(resolved_title)
@@ -206,7 +209,7 @@ class Generator
   end
 
   def apply_primitive_test_type_config!(test_config, test, test_type_id, resolved_title, resolved_description)
-    if test_type_id == :bundle_valid
+    if BUNDLE_VALID_TEST_TYPE_IDS.include?(test_type_id)
       test_config[:base_class_name] = test[:base_class_name]
       test_config[:imports] = test[:imports]
       test_config[:ignore_commands] = test[:ignore_commands]

--- a/lib/au_ps_inferno/generator/suite_structure.rb
+++ b/lib/au_ps_inferno/generator/suite_structure.rb
@@ -8,15 +8,16 @@ class Generator
   #
   # Tests are referenced by symbol id. Add a new test type: add { id: :new_id } to the appropriate group
   # in SHARED_GROUP_DEFINITIONS and register title/description/config in TestConfigRegistry.
-  # :bundle_valid is a special case; its title/description/config come from HIGH_ORDER_GROUP_CONFIGS.
+  # :bundle_valid and :bundle_valid_ips are special cases; their title/description/config come from
+  # HIGH_ORDER_GROUP_CONFIGS.
   #
   # To add a new high-order group: add an entry to HIGH_ORDER_GROUP_CONFIGS.
   # To add a new shared group: add to SHARED_GROUP_DEFINITIONS with tests: [ { id: :... }, ... ].
   module SuiteStructure
     # Builds the full HIGH_ORDER_GROUPS structure expected by Generator (array of hashes with
     # :name, :description, :groups).
-    # Each group's tests are hashes with :id and, for :bundle_valid, :title, :description,
-    # :base_class_name, :imports, :ignore_commands.
+    # Each group's tests are hashes with :id and, for :bundle_valid / :bundle_valid_ips, :title,
+    # :description, :base_class_name, :imports, :ignore_commands.
     #
     # @return [Array<Hash>] same shape as the former Generator::HIGH_ORDER_GROUPS with :description added
     def self.expand_high_order_groups
@@ -41,6 +42,7 @@ class Generator
 
     def self.map_test_item(test_item, config)
       return bundle_valid_test_hash(config) if test_item == BUNDLE_VALIDATION_PLACEHOLDER
+      return bundle_valid_ips_test_hash(config) if test_item == BUNDLE_VALIDATION_IPS_PLACEHOLDER
 
       { id: test_item[:id] }
     end
@@ -51,6 +53,17 @@ class Generator
         title: config[:bundle_validation_title],
         description: config[:bundle_validation_description],
         base_class_name: config[:bundle_validation_base_class_name],
+        imports: config[:bundle_validation_imports],
+        ignore_commands: true
+      }
+    end
+
+    def self.bundle_valid_ips_test_hash(config)
+      {
+        id: :bundle_valid_ips,
+        title: config[:bundle_validation_ips_title],
+        description: config[:bundle_validation_ips_description],
+        base_class_name: config[:bundle_validation_ips_base_class_name],
         imports: config[:bundle_validation_imports],
         ignore_commands: true
       }

--- a/lib/au_ps_inferno/generator/suite_structure/definitions.rb
+++ b/lib/au_ps_inferno/generator/suite_structure/definitions.rb
@@ -9,8 +9,8 @@ class Generator
 
     SHARED_GROUP_DEFINITIONS = [
       {
-        name: 'AU PS Bundle Validation',
-        description: 'Validates that the bundle conforms to the AU PS Bundle profile.',
+        name: 'Bundle Validation',
+        description: 'Validates that the bundle conforms to the Bundle profiles.',
         tests: [BUNDLE_VALIDATION_PLACEHOLDER],
         run_as_group: true
       },
@@ -128,7 +128,7 @@ class Generator
         bundle_validation_description: 'The Bundle resource is valid against the AU PS Bundle profile ' \
                                        'using FHIR validator',
         bundle_validation_base_class_name: 'BundleIsValidClass',
-        bundle_validation_imports: ['../../../utils/bundle_is_valid_class'],
+        bundle_validation_imports: ['../../../utils/bundle_is_valid_class', '../../../utils/ips_bundle_is_valid_class'],
         run_as_group: true
       },
       {
@@ -139,7 +139,8 @@ class Generator
         bundle_validation_description: 'Verifies that a bundle retrieved from the server conforms to the ' \
                                        'AU PS Bundle profile.',
         bundle_validation_base_class_name: 'RetrieveBundleTestClass',
-        bundle_validation_imports: ['../../../utils/retrieve_bundle_test_class'],
+        bundle_validation_imports: ['../../../utils/retrieve_bundle_test_class',
+                                    '../../../utils/ips_retrieve_bundle_test_class'],
         run_as_group: true
       },
       {
@@ -150,7 +151,8 @@ class Generator
         bundle_validation_description: 'Verifies that a bundle produced by the IPS $summary operation ' \
                                        'conforms to the AU PS Bundle profile.',
         bundle_validation_base_class_name: 'SummaryValidBundleClass',
-        bundle_validation_imports: ['../../../utils/summary_valid_bundle_class'],
+        bundle_validation_imports: ['../../../utils/summary_valid_bundle_class',
+                                    '../../../utils/ips_summary_valid_bundle_class'],
         run_as_group: true
       }
     ].freeze

--- a/lib/au_ps_inferno/generator/suite_structure/definitions.rb
+++ b/lib/au_ps_inferno/generator/suite_structure/definitions.rb
@@ -3,15 +3,16 @@
 # rubocop:disable Metrics/ModuleLength
 class Generator
   module SuiteStructure
-    # Placeholder for the single test in "Bundle Validation"; each high-order group supplies its own
+    # Placeholders for the two tests in "Bundle Validation"; each high-order group supplies its own
     # title, description, and base class via HIGH_ORDER_GROUP_CONFIGS.
     BUNDLE_VALIDATION_PLACEHOLDER = :bundle_valid
+    BUNDLE_VALIDATION_IPS_PLACEHOLDER = :bundle_valid_ips
 
     SHARED_GROUP_DEFINITIONS = [
       {
         name: 'Bundle Validation',
         description: 'Validates that the bundle conforms to the Bundle profiles.',
-        tests: [BUNDLE_VALIDATION_PLACEHOLDER],
+        tests: [BUNDLE_VALIDATION_PLACEHOLDER, BUNDLE_VALIDATION_IPS_PLACEHOLDER],
         run_as_group: true
       },
       {
@@ -129,6 +130,10 @@ class Generator
                                        'using FHIR validator',
         bundle_validation_base_class_name: 'BundleIsValidClass',
         bundle_validation_imports: ['../../../utils/bundle_is_valid_class', '../../../utils/ips_bundle_is_valid_class'],
+        bundle_validation_ips_title: 'AU PS Bundle is valid against IPS Bundle profile',
+        bundle_validation_ips_description: 'The Bundle resource is valid against the IPS Bundle profile ' \
+                                           'using FHIR validator',
+        bundle_validation_ips_base_class_name: 'IpsBundleIsValidClass',
         run_as_group: true
       },
       {
@@ -141,6 +146,10 @@ class Generator
         bundle_validation_base_class_name: 'RetrieveBundleTestClass',
         bundle_validation_imports: ['../../../utils/retrieve_bundle_test_class',
                                     '../../../utils/ips_retrieve_bundle_test_class'],
+        bundle_validation_ips_title: 'Retrieved Bundle is valid against IPS Bundle profile',
+        bundle_validation_ips_description: 'Verifies that a bundle retrieved from the server conforms to the ' \
+                                           'IPS Bundle profile.',
+        bundle_validation_ips_base_class_name: 'IpsRetrieveBundleTestClass',
         run_as_group: true
       },
       {
@@ -153,6 +162,10 @@ class Generator
         bundle_validation_base_class_name: 'SummaryValidBundleClass',
         bundle_validation_imports: ['../../../utils/summary_valid_bundle_class',
                                     '../../../utils/ips_summary_valid_bundle_class'],
+        bundle_validation_ips_title: 'Generated Bundle is valid against IPS Bundle profile',
+        bundle_validation_ips_description: 'Verifies that a bundle produced by the IPS $summary operation ' \
+                                           'conforms to the IPS Bundle profile.',
+        bundle_validation_ips_base_class_name: 'IpsSummaryValidBundleClass',
         run_as_group: true
       }
     ].freeze

--- a/lib/au_ps_inferno/generator/suite_structure/definitions.rb
+++ b/lib/au_ps_inferno/generator/suite_structure/definitions.rb
@@ -125,14 +125,12 @@ class Generator
         name: 'AU PS Bundle Instance',
         description: 'Validates a static AU PS bundle instance for profile conformance, Must Support ' \
                      'elements, and composition sections.',
-        bundle_validation_title: 'AU PS Bundle is valid against AU PS Bundle profile',
-        bundle_validation_description: 'The Bundle resource is valid against the AU PS Bundle profile ' \
-                                       'using FHIR validator',
+        bundle_validation_title: 'Bundle is valid against AU PS Bundle',
+        bundle_validation_description: 'The Bundle resource is valid against the AU PS Bundle profile using FHIR validator',
         bundle_validation_base_class_name: 'BundleIsValidClass',
         bundle_validation_imports: ['../../../utils/bundle_is_valid_class', '../../../utils/ips_bundle_is_valid_class'],
-        bundle_validation_ips_title: 'AU PS Bundle is valid against IPS Bundle profile',
-        bundle_validation_ips_description: 'The Bundle resource is valid against the IPS Bundle profile ' \
-                                           'using FHIR validator',
+        bundle_validation_ips_title: 'Bundle is valid against IPS Bundle',
+        bundle_validation_ips_description: 'The Bundle resource is valid against the IPS Bundle profile using FHIR validator',
         bundle_validation_ips_base_class_name: 'IpsBundleIsValidClass',
         run_as_group: true
       },

--- a/lib/au_ps_inferno/generator/templates/au_ps_specific_section_validation_test.rb.erb
+++ b/lib/au_ps_inferno/generator/templates/au_ps_specific_section_validation_test.rb.erb
@@ -25,7 +25,6 @@ module AUPSTestKit
       resource = FHIR.from_contents(bundle_resource)
       scratch[:bundle_ips_resource] = resource
       save_bundle_entities_to_scratch(scratch_bundle)
-      info "Bundle resource saved to scratch: #{scratch_bundle}"
     end
 
     run do

--- a/lib/au_ps_inferno/utils/basic_test/bundle_module.rb
+++ b/lib/au_ps_inferno/utils/basic_test/bundle_module.rb
@@ -26,15 +26,23 @@ module AUPSTestKit
       false
     end
 
+    def validate_au_ps_bundle
+      validate_bundle_wrapper('http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-bundle|1.0.0-ballot')
+    end
+
     def validate_ips_bundle
-      check_bundle_exists_in_scratch
-      validate_bundle(
-        scratch_bundle,
-        'http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-bundle|1.0.0-ballot'
-      )
+      validate_bundle_wrapper('http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips')
     end
 
     private
+
+    def validate_bundle_wrapper(profile_with_version)
+      check_bundle_exists_in_scratch
+      validate_bundle(
+        scratch_bundle,
+        profile_with_version
+      )
+    end
 
     def validate_bundle(resource, profile_with_version)
       return if skip_validation?

--- a/lib/au_ps_inferno/utils/basic_test/composition_section_check_resources_ms_elements_module.rb
+++ b/lib/au_ps_inferno/utils/basic_test/composition_section_check_resources_ms_elements_module.rb
@@ -8,8 +8,8 @@ module AUPSTestKit
     module BasicTestCompositionSectionCheckResourcesMSElementsModule # rubocop:disable Metrics/ModuleLength
       AU_PS_PROFILE_BASE_URL = 'http://hl7.org.au/fhir/ps/StructureDefinition/'
 
-      def check_ms_elements_populated(resource_type, resources, all_present: false)
-        profile_metadata = group_metadata_for(resource_type)
+      def check_ms_elements_populated(profile_url, resources, all_present: false)
+        profile_metadata = group_metadata_for(profile_url)
         collapsed_elements_statuses(ms_checker_for(profile_metadata).elements_present_statuses(resources, all_present:))
       end
 
@@ -116,7 +116,7 @@ module AUPSTestKit
 
       def build_ms_outcome(profile_metadata, resources, section_context = nil, all_present: false)
         ms_helper = ms_checker_for(profile_metadata, section_context)
-        ms_checks_results = check_ms_elements_populated(profile_metadata.resource, resources, all_present:)
+        ms_checks_results = check_ms_elements_populated(profile_metadata.profile_url, resources, all_present:)
 
         {
           status: ms_helper.calculate_elements_status_message_level(ms_checks_results),
@@ -125,11 +125,11 @@ module AUPSTestKit
       end
 
       def process_profile(section_profile, resources_to_check_ms, all_present: false)
-        profile_info_str, filtered_resources, resource_type =
+        profile_info_str, filtered_resources, _, profile_url =
           build_profile_context(section_profile, resources_to_check_ms)
         return report_missing_resources(profile_info_str) if filtered_resources.blank?
 
-        profile_metadata = group_metadata_for(resource_type)
+        profile_metadata = group_metadata_for(profile_url)
         outcome = build_ms_outcome(profile_metadata, filtered_resources, section_profile, all_present:)
         add_message(outcome[:status], outcome[:message].join("\n\n"))
 
@@ -142,15 +142,15 @@ module AUPSTestKit
         profile_info_str = msg_line('Profile', "#{resource_type} — #{profile_url}")
         filtered_resources = resources_by_type(resources_to_check_ms, resource_type)
 
-        [profile_info_str, filtered_resources, resource_type]
+        [profile_info_str, filtered_resources, resource_type, profile_url]
       end
 
       def resources_by_type(resources, resource_type)
         resources.filter { |resource| resource.resourceType == resource_type }
       end
 
-      def group_metadata_for(resource_type)
-        resource_metadata_raw = metadata_manager.group_metadata_by_resource_type(resource_type)
+      def group_metadata_for(profile_url)
+        resource_metadata_raw = metadata_manager.group_metadata_by_profile_url(profile_url)
         InfernoSuiteGenerator::Generator::GroupMetadata.new(resource_metadata_raw)
       end
 

--- a/lib/au_ps_inferno/utils/basic_test/ms_sub_elements_populated_module.rb
+++ b/lib/au_ps_inferno/utils/basic_test/ms_sub_elements_populated_module.rb
@@ -109,7 +109,8 @@ module AUPSTestKit
     end
 
     def parent_element_is_not_populated?(sub_elements, results)
-      results.any? { |result| result[:path] == sub_elements[0][:path] && result[:present] == false }
+      parent_path = sub_elements[0][:path].split('.').first
+      results.any? { |result| result[:path] == parent_path && result[:present] == false }
     end
 
     def parent_element_is_not_populated_text(parent_path, sub_elements)

--- a/lib/au_ps_inferno/utils/basic_test/ms_sub_elements_populated_module.rb
+++ b/lib/au_ps_inferno/utils/basic_test/ms_sub_elements_populated_module.rb
@@ -32,6 +32,7 @@ module AUPSTestKit
 
     def get_metadata_by_resource_type(resource_type)
       raw_metadata = metadata_manager.group_metadata_by_resource_type(resource_type)
+      return nil unless raw_metadata.present?
 
       InfernoSuiteGenerator::Generator::GroupMetadata.new(raw_metadata)
     end

--- a/lib/au_ps_inferno/utils/basic_validate_bundle_test.rb
+++ b/lib/au_ps_inferno/utils/basic_validate_bundle_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module AUPSTestKit
+  # Basic test for validating a Bundle resource against the AU PS Bundle or IPS Bundle profile
+  class BasicValidateBundleTest < BasicTest
+    id :basic_validate_bundle_test
+
+    input :validate_against,
+          title: 'Validate Against',
+          optional: true,
+          type: 'checkbox',
+          default: ['au_ps_bundle'],
+          options: {
+            list_options: [
+              {
+                label: 'AU PS Bundle Validation',
+                value: 'au_ps_bundle'
+              },
+              {
+                label: 'IPS Bundle Validation',
+                value: 'ips_bundle'
+              }
+            ]
+          }
+  end
+end

--- a/lib/au_ps_inferno/utils/basic_validate_bundle_test.rb
+++ b/lib/au_ps_inferno/utils/basic_validate_bundle_test.rb
@@ -3,6 +3,9 @@
 module AUPSTestKit
   # Basic test for validating a Bundle resource against the AU PS Bundle or IPS Bundle profile
   class BasicValidateBundleTest < BasicTest
+    OMIT_AU_PS_MESSAGE = 'Validation against AU PS Bundle is disabled'
+    OMIT_IPS_MESSAGE = 'Validation against IPS Bundle is disabled'
+
     id :basic_validate_bundle_test
 
     input :validate_against,
@@ -22,5 +25,19 @@ module AUPSTestKit
               }
             ]
           }
+
+    def omit_au_ps_validation?
+      omit_test_wrapper('au_ps_bundle')
+    end
+
+    def omit_ips_validation?
+      omit_test_wrapper('ips_bundle')
+    end
+
+    private
+
+    def omit_test_wrapper?(include_str)
+      validate_against.blank? || !validate_against.include?(include_str)
+    end
   end
 end

--- a/lib/au_ps_inferno/utils/basic_validate_bundle_test.rb
+++ b/lib/au_ps_inferno/utils/basic_validate_bundle_test.rb
@@ -27,16 +27,16 @@ module AUPSTestKit
           }
 
     def omit_au_ps_validation?
-      omit_test_wrapper('au_ps_bundle')
+      omit_test_wrapper?('au_ps_bundle')
     end
 
     def omit_ips_validation?
-      omit_test_wrapper('ips_bundle')
+      omit_test_wrapper?('ips_bundle')
     end
 
     private
 
-    def omit_test_wrapper(include_str)
+    def omit_test_wrapper?(include_str)
       validate_against.blank? || !validate_against.include?(include_str)
     end
   end

--- a/lib/au_ps_inferno/utils/basic_validate_bundle_test.rb
+++ b/lib/au_ps_inferno/utils/basic_validate_bundle_test.rb
@@ -12,7 +12,7 @@ module AUPSTestKit
           title: 'Validate Against',
           optional: true,
           type: 'checkbox',
-          default: %w[au_ps_bundle ips_bundle],
+          default: %w[au_ps_bundle],
           options: {
             list_options: [
               {

--- a/lib/au_ps_inferno/utils/basic_validate_bundle_test.rb
+++ b/lib/au_ps_inferno/utils/basic_validate_bundle_test.rb
@@ -12,7 +12,7 @@ module AUPSTestKit
           title: 'Validate Against',
           optional: true,
           type: 'checkbox',
-          default: ['au_ps_bundle'],
+          default: %w[au_ps_bundle ips_bundle],
           options: {
             list_options: [
               {
@@ -36,7 +36,7 @@ module AUPSTestKit
 
     private
 
-    def omit_test_wrapper?(include_str)
+    def omit_test_wrapper(include_str)
       validate_against.blank? || !validate_against.include?(include_str)
     end
   end

--- a/lib/au_ps_inferno/utils/bundle_is_valid_class.rb
+++ b/lib/au_ps_inferno/utils/bundle_is_valid_class.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require_relative 'basic_test_class'
+require_relative 'basic_validate_bundle_test'
 
 module AUPSTestKit
   # The Bundle resource is valid against the AU PS Bundle profile
-  class BundleIsValidClass < BasicTest
+  class BundleIsValidClass < BasicValidateBundleTest
     id :bundle_is_valid_class_test
     input :bundle_resource,
           optional: true,
@@ -15,8 +15,12 @@ module AUPSTestKit
       bundle_resource.blank?
     end
 
+    def omit_test?
+      validate_against.blank? || !validate_against.include?('au_ps_bundle')
+    end
+
     def read_and_save_data
-      info 'Validate provided Bundle resource'
+      info 'Reading and saving provided Bundle resource'
       resource = FHIR.from_contents(bundle_resource)
       scratch[:bundle_ips_resource] = resource
       save_bundle_entities_to_scratch(scratch_bundle)
@@ -26,7 +30,8 @@ module AUPSTestKit
     run do
       skip_if skip_test?, 'No Bundle resource provided'
       read_and_save_data
-      validate_ips_bundle
+      omit_if omit_test?, 'Validation against AU PS Bundle is disabled'
+      validate_au_ps_bundle
     end
   end
 end

--- a/lib/au_ps_inferno/utils/bundle_is_valid_class.rb
+++ b/lib/au_ps_inferno/utils/bundle_is_valid_class.rb
@@ -15,10 +15,6 @@ module AUPSTestKit
       bundle_resource.blank?
     end
 
-    def omit_test?
-      validate_against.blank? || !validate_against.include?('au_ps_bundle')
-    end
-
     def read_and_save_data
       info 'Reading and saving provided Bundle resource'
       resource = FHIR.from_contents(bundle_resource)
@@ -30,7 +26,7 @@ module AUPSTestKit
     run do
       skip_if skip_test?, 'No Bundle resource provided'
       read_and_save_data
-      omit_if omit_test?, 'Validation against AU PS Bundle is disabled'
+      omit_if omit_au_ps_validation?, OMIT_AU_PS_MESSAGE
       validate_au_ps_bundle
     end
   end

--- a/lib/au_ps_inferno/utils/bundle_is_valid_class.rb
+++ b/lib/au_ps_inferno/utils/bundle_is_valid_class.rb
@@ -16,11 +16,9 @@ module AUPSTestKit
     end
 
     def read_and_save_data
-      info 'Reading and saving provided Bundle resource'
       resource = FHIR.from_contents(bundle_resource)
       scratch[:bundle_ips_resource] = resource
       save_bundle_entities_to_scratch(scratch_bundle)
-      info "Bundle resource saved to scratch: #{scratch_bundle}"
     end
 
     run do

--- a/lib/au_ps_inferno/utils/ips_bundle_is_valid_class.rb
+++ b/lib/au_ps_inferno/utils/ips_bundle_is_valid_class.rb
@@ -8,8 +8,6 @@ module AUPSTestKit
     id :ips_bundle_is_valid_class_base
 
     run do
-      skip_if skip_test?, 'No Bundle resource provided'
-      read_and_save_data
       omit_if omit_ips_validation?, OMIT_IPS_MESSAGE
       validate_ips_bundle
     end

--- a/lib/au_ps_inferno/utils/ips_bundle_is_valid_class.rb
+++ b/lib/au_ps_inferno/utils/ips_bundle_is_valid_class.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'bundle_is_valid_class'
+
+module AUPSTestKit
+  # The Bundle resource is valid against the IPS Bundle profile
+  class IpsBundleIsValidClass < BundleIsValidClass
+    id :ips_bundle_is_valid_class_base
+
+    run do
+      skip_if skip_test?, 'No Bundle resource provided'
+      read_and_save_data
+      omit_if !ips_bundle_validation_enabled?, 'IPS Bundle validation is disabled'
+      validate_ips_bundle
+    end
+  end
+end

--- a/lib/au_ps_inferno/utils/ips_bundle_is_valid_class.rb
+++ b/lib/au_ps_inferno/utils/ips_bundle_is_valid_class.rb
@@ -10,7 +10,7 @@ module AUPSTestKit
     run do
       skip_if skip_test?, 'No Bundle resource provided'
       read_and_save_data
-      omit_if !ips_bundle_validation_enabled?, 'IPS Bundle validation is disabled'
+      omit_if omit_ips_validation?, OMIT_IPS_MESSAGE
       validate_ips_bundle
     end
   end

--- a/lib/au_ps_inferno/utils/ips_retrieve_bundle_test_class.rb
+++ b/lib/au_ps_inferno/utils/ips_retrieve_bundle_test_class.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'retrieve_bundle_test_class'
+
+module AUPSTestKit
+  # Retrieve a bundle and validate against the IPS Bundle profile
+  class IpsRetrieveBundleTestClass < RetrieveBundleTestClass
+    id :ips_retrieve_bundle_test_class_base
+
+    run do
+      skip_if skip_test?, 'There is no FHIR server URL, Bundle ID or Bundle URL provided'
+      read_and_save_data
+      omit_if !ips_bundle_validation_enabled?, 'IPS Bundle validation is disabled'
+      validate_ips_bundle
+    end
+  end
+end

--- a/lib/au_ps_inferno/utils/ips_retrieve_bundle_test_class.rb
+++ b/lib/au_ps_inferno/utils/ips_retrieve_bundle_test_class.rb
@@ -10,7 +10,7 @@ module AUPSTestKit
     run do
       skip_if skip_test?, 'There is no FHIR server URL, Bundle ID or Bundle URL provided'
       read_and_save_data
-      omit_if !ips_bundle_validation_enabled?, 'IPS Bundle validation is disabled'
+      omit_if omit_ips_validation?, OMIT_IPS_MESSAGE
       validate_ips_bundle
     end
   end

--- a/lib/au_ps_inferno/utils/ips_summary_valid_bundle_class.rb
+++ b/lib/au_ps_inferno/utils/ips_summary_valid_bundle_class.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'summary_valid_bundle_class'
+
+module AUPSTestKit
+  # Bundle from $summary validated against the IPS Bundle profile
+  class IpsSummaryValidBundleClass < SummaryValidBundleClass
+    id :ips_summary_valid_bundle_class_base
+
+    run do
+      skip_if url.blank?, 'No FHIR server specified'
+      summary_op_defined? if scratch[:summary_op_defined].blank?
+      skip_if scratch[:summary_op_defined] == false, 'Server does not declare support for $summary operation'
+      read_and_save_data
+      omit_if !ips_bundle_validation_enabled?, 'IPS Bundle validation is disabled'
+      validate_ips_bundle
+    end
+  end
+end

--- a/lib/au_ps_inferno/utils/ips_summary_valid_bundle_class.rb
+++ b/lib/au_ps_inferno/utils/ips_summary_valid_bundle_class.rb
@@ -12,7 +12,7 @@ module AUPSTestKit
       summary_op_defined? if scratch[:summary_op_defined].blank?
       skip_if scratch[:summary_op_defined] == false, 'Server does not declare support for $summary operation'
       read_and_save_data
-      omit_if !ips_bundle_validation_enabled?, 'IPS Bundle validation is disabled'
+      omit_if omit_ips_validation?, OMIT_IPS_MESSAGE
       validate_ips_bundle
     end
   end

--- a/lib/au_ps_inferno/utils/ips_summary_valid_bundle_class.rb
+++ b/lib/au_ps_inferno/utils/ips_summary_valid_bundle_class.rb
@@ -8,10 +8,6 @@ module AUPSTestKit
     id :ips_summary_valid_bundle_class_base
 
     run do
-      skip_if url.blank?, 'No FHIR server specified'
-      summary_op_defined? if scratch[:summary_op_defined].blank?
-      skip_if scratch[:summary_op_defined] == false, 'Server does not declare support for $summary operation'
-      read_and_save_data
       omit_if omit_ips_validation?, OMIT_IPS_MESSAGE
       validate_ips_bundle
     end

--- a/lib/au_ps_inferno/utils/retrieve_bundle_test_class.rb
+++ b/lib/au_ps_inferno/utils/retrieve_bundle_test_class.rb
@@ -43,16 +43,13 @@ module AUPSTestKit
     end
 
     def get_bundle_resource_from_fhir_server(bundle_id)
-      info "Retrieving Bundle resource with id #{bundle_id}"
       fhir_read(:bundle, bundle_id)
       assert_response_status(200)
       assert_resource_type(:bundle)
       scratch[:bundle_ips_resource] = resource
-      info "Bundle resource saved to scratch: #{scratch_bundle}"
     end
 
     def get_bundle_resource_from_url(bundle_url)
-      info "Retrieving Bundle resource from url #{bundle_url}"
       uri = URI(bundle_url)
       response = Net::HTTP.get_response(uri)
       assert response.code == '200', "Bundle resource not found at #{bundle_url}"
@@ -60,7 +57,6 @@ module AUPSTestKit
       assert bundle_resource.resourceType == 'Bundle', 'Resource have different type than Bundle'
       scratch[:bundle_ips_resource] = bundle_resource
       save_bundle_entities_to_scratch(scratch_bundle)
-      info "Bundle resource saved to scratch: #{scratch_bundle}"
     end
 
     def skip_test?

--- a/lib/au_ps_inferno/utils/retrieve_bundle_test_class.rb
+++ b/lib/au_ps_inferno/utils/retrieve_bundle_test_class.rb
@@ -78,6 +78,7 @@ module AUPSTestKit
     run do
       skip_if skip_test?, 'There is no FHIR server URL, Bundle ID or Bundle URL provided'
       read_and_save_data
+      omit_if omit_au_ps_validation?, OMIT_AU_PS_MESSAGE
       validate_au_ps_bundle
     end
   end

--- a/lib/au_ps_inferno/utils/retrieve_bundle_test_class.rb
+++ b/lib/au_ps_inferno/utils/retrieve_bundle_test_class.rb
@@ -3,11 +3,11 @@
 require 'net/http'
 require 'uri'
 
-require_relative 'basic_test_class'
+require_relative 'basic_validate_bundle_test'
 
 module AUPSTestKit
   # A base class for all tests that retrieve a Bundle resource
-  class RetrieveBundleTestClass < BasicTest
+  class RetrieveBundleTestClass < BasicValidateBundleTest
     id :retrieve_bundle_test_class
     input_order :bundle_url, :url, :bundle_id, :credentials, :header_name, :header_value
 
@@ -78,7 +78,7 @@ module AUPSTestKit
     run do
       skip_if skip_test?, 'There is no FHIR server URL, Bundle ID or Bundle URL provided'
       read_and_save_data
-      validate_ips_bundle
+      validate_au_ps_bundle
     end
   end
 end

--- a/lib/au_ps_inferno/utils/summary_valid_bundle_class.rb
+++ b/lib/au_ps_inferno/utils/summary_valid_bundle_class.rb
@@ -79,6 +79,7 @@ module AUPSTestKit
       summary_op_defined? if scratch[:summary_op_defined].blank?
       skip_if scratch[:summary_op_defined] == false, 'Server does not declare support for $summary operation'
       read_and_save_data
+      omit_if omit_au_ps_validation?, OMIT_AU_PS_MESSAGE
       validate_au_ps_bundle
     end
   end

--- a/lib/au_ps_inferno/utils/summary_valid_bundle_class.rb
+++ b/lib/au_ps_inferno/utils/summary_valid_bundle_class.rb
@@ -3,11 +3,11 @@
 require 'net/http'
 require 'uri'
 
-require_relative 'basic_test_class'
+require_relative 'basic_validate_bundle_test'
 
 module AUPSTestKit
   # The Bundle resource is valid against the AU PS Bundle profile
-  class SummaryValidBundleClass < BasicTest
+  class SummaryValidBundleClass < BasicValidateBundleTest
     id :summary_valid_bundle_class_test
     input_order :url, :patient_id, :identifier, :profile, :credentials, :header_name, :header_value
 
@@ -79,7 +79,7 @@ module AUPSTestKit
       summary_op_defined? if scratch[:summary_op_defined].blank?
       skip_if scratch[:summary_op_defined] == false, 'Server does not declare support for $summary operation'
       read_and_save_data
-      validate_ips_bundle
+      validate_au_ps_bundle
     end
   end
 end

--- a/lib/au_ps_inferno/utils/summary_valid_bundle_class.rb
+++ b/lib/au_ps_inferno/utils/summary_valid_bundle_class.rb
@@ -64,14 +64,12 @@ module AUPSTestKit
     end
 
     def read_and_save_data
-      info 'Making $summary operation request'
       response = fhir_operation(operation_path, name: :summary_operation, operation_method: :get)
       assert_response_status(200)
       assert_resource_type(:bundle)
       resource_from_request = FHIR.from_contents(response.response_body)
       scratch[:bundle_ips_resource] = resource_from_request
       save_bundle_entities_to_scratch(scratch_bundle)
-      info "Bundle resource saved to scratch: #{scratch_bundle}"
     end
 
     run do

--- a/spec/support/basic_test/ms_elements_populated_spec_support.rb
+++ b/spec/support/basic_test/ms_elements_populated_spec_support.rb
@@ -14,10 +14,10 @@ RSpec.shared_context 'ms elements populated setup' do
     end
   end
 
-  def get_ms_elements_paths(resource_type)
-    metadata_manager.group_metadata_by_resource_type(resource_type)[:must_supports][:elements].map do |e|
-      e[:path]
-    end
+  def get_ms_elements_paths(profile_url)
+    metadata = metadata_manager.group_metadata_by_profile_url(profile_url)
+
+    metadata&.dig(:must_supports, :elements)&.map { |e| e[:path] } || []
   end
 
   before { test_instance.metadata_manager = metadata_manager }

--- a/spec/unit/basic_test/composition_section_check_resources_ms_elements_module_spec.rb
+++ b/spec/unit/basic_test/composition_section_check_resources_ms_elements_module_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe AUPSTestKit::BasicTestCompositionSectionReadModule::BasicTestComp
       groups: [
         {
           resource: 'Condition',
+          profile_url: 'http://hl7.org.au/fhir/ps/StructureDefinition/condition',
           must_supports: {
             elements: [
               { path: 'clinicalStatus' },
@@ -40,7 +41,7 @@ RSpec.describe AUPSTestKit::BasicTestCompositionSectionReadModule::BasicTestComp
     }
   end
 
-  target_resource_type = 'Condition'
+  target_profile_url = 'http://hl7.org.au/fhir/ps/StructureDefinition/condition'
   resources_array = [FHIR::Condition.new(
     {
       resourceType: 'Condition',
@@ -53,7 +54,7 @@ RSpec.describe AUPSTestKit::BasicTestCompositionSectionReadModule::BasicTestComp
 
   describe '#check_ms_elements_populated' do # rubocop:disable Metrics/BlockLength
     it 'returns expected result shape as array of hashes with keys :definition, :mandatory, :path, :present' do
-      result = test_instance.check_ms_elements_populated(target_resource_type, resources_array)
+      result = test_instance.check_ms_elements_populated(target_profile_url, resources_array)
 
       expect(result).to be_an(Array)
       expect(result).to all(be_a(Hash))
@@ -61,8 +62,8 @@ RSpec.describe AUPSTestKit::BasicTestCompositionSectionReadModule::BasicTestComp
     end
 
     it 'returns paths from metadata must_support elements' do
-      ms_elements_paths = get_ms_elements_paths(target_resource_type)
-      result = test_instance.check_ms_elements_populated(target_resource_type, resources_array)
+      ms_elements_paths = get_ms_elements_paths(target_profile_url)
+      result = test_instance.check_ms_elements_populated(target_profile_url, resources_array)
       actual_paths = result.map { |item| item[:path] }
 
       expect(actual_paths).to match_array(ms_elements_paths)
@@ -72,7 +73,7 @@ RSpec.describe AUPSTestKit::BasicTestCompositionSectionReadModule::BasicTestComp
       expected_mandatory_values = ['category', 'code', 'subject', 'subject.reference']
       expected_optional_values = ['clinicalStatus', 'verificationStatus', 'severity', 'onsetDateTime', 'abatement[x]',
                                   'note']
-      result = test_instance.check_ms_elements_populated(target_resource_type, resources_array)
+      result = test_instance.check_ms_elements_populated(target_profile_url, resources_array)
       mandatory_values = result.map { |item| item[:path] if item[:mandatory] }.compact
       optional_values = result.map { |item| item[:path] unless item[:mandatory] }.compact
 
@@ -83,7 +84,7 @@ RSpec.describe AUPSTestKit::BasicTestCompositionSectionReadModule::BasicTestComp
     it 'correctly marks presence for each element' do
       expected_values_to_populate = ['clinicalStatus', 'category', 'code', 'subject', 'subject.reference']
       expected_values_to_empty = ['verificationStatus', 'severity', 'onsetDateTime', 'abatement[x]', 'note']
-      result = test_instance.check_ms_elements_populated(target_resource_type, resources_array)
+      result = test_instance.check_ms_elements_populated(target_profile_url, resources_array)
 
       populated_values = result.map { |item| item[:path] if item[:present] }.compact
       empty_values = result.map { |item| item[:path] unless item[:present] }.compact
@@ -93,7 +94,7 @@ RSpec.describe AUPSTestKit::BasicTestCompositionSectionReadModule::BasicTestComp
     end
 
     it 'returns all must-support elements as missing when no resources are provided' do
-      result = test_instance.check_ms_elements_populated(target_resource_type, [])
+      result = test_instance.check_ms_elements_populated(target_profile_url, [])
 
       expect(result.map { |item| item[:present] }.uniq).to eq([false])
     end


### PR DESCRIPTION
## Changes

- Adds IPS Bundle profile validation as a second test alongside the existing AU PS Bundle validation, for all three bundle test scenarios (static instance, retrieved from server, $summary operation).
- Introduces BasicValidateBundleTest base class with a validate_against checkbox input so users can opt into AU PS, IPS, or both validations per run.
- Refactors BundleModule#validate_ips_bundle → validate_au_ps_bundle / validate_ips_bundle backed by a shared validate_bundle_wrapper to eliminate duplication.
- Adds three new IPS-specific test classes (IpsBundleIsValidClass, IpsRetrieveBundleTestClass, IpsSummaryValidBundleClass) that inherit from their AU PS counterparts and apply the IPS omit guard.
- Extends SuiteStructure with BUNDLE_VALIDATION_IPS_PLACEHOLDER and a bundle_valid_ips test type; renames the shared group from "AU PS Bundle Validation" to "Bundle Validation".
- Cleans up info logging statements from bundle retrieval and save steps.