### PR TITLE
Fix labels for composition validation

### DIFF
--- a/lib/au_ps_inferno/utils/basic_test/composition_elements_and_slices_module.rb
+++ b/lib/au_ps_inferno/utils/basic_test/composition_elements_and_slices_module.rb
@@ -11,7 +11,9 @@ module AUPSTestKit
 
       result = all_paths_are_populated?(composition_resource, elements_array)
       msg_type = composition_elements_message_type(result, required)
-      add_message(msg_type, populated_paths_info(composition_resource, elements_array))
+      add_message(msg_type,
+                  populated_paths_info(composition_resource, elements_array,
+                                       mandatory_array: required ? elements_array : []))
       assert_composition_elements_if_required(result, required)
     end
 
@@ -52,7 +54,7 @@ module AUPSTestKit
 
     def composition_slice_validation_passes?(composition_resource, slice, event)
       paths = composition_slice_element_paths(slice)
-      message_data = populated_paths_info(composition_resource, paths[:combined])
+      message_data = populated_paths_info(composition_resource, paths[:combined], mandatory_array: paths[:required])
       full_data = composition_slice_full_message_data(message_data)
       return false unless composition_slice_required_paths_ok?(composition_resource, paths, full_data)
 

--- a/lib/au_ps_inferno/utils/basic_test/composition_subelements_module.rb
+++ b/lib/au_ps_inferno/utils/basic_test/composition_subelements_module.rb
@@ -60,7 +60,7 @@ module AUPSTestKit
       end
 
       level = composition_subelements_worst_level(composition_resource, sub_elements, mandatory_ms)
-      add_message(level, populated_paths_info(composition_resource, sub_elements))
+      add_message(level, populated_paths_info(composition_resource, sub_elements, mandatory_array: mandatory_ms))
     end
 
     def composition_subelement_parent_unpopulated_message(parent_path, sub_elements)

--- a/lib/au_ps_inferno/utils/basic_test/paths_module.rb
+++ b/lib/au_ps_inferno/utils/basic_test/paths_module.rb
@@ -5,10 +5,14 @@ module AUPSTestKit
   module BasicTestPathsModule
     private
 
-    def populated_paths_info(resource, elements_array)
+    def populated_paths_info(resource, elements_array, mandatory_array: [])
       title = '## List of populated elements'
       result = elements_array.map do |element|
-        "#{boolean_to_existent_string(resolve_path_with_dar(resource, element).first.present?)}: **#{element}**"
+        mandatory = mandatory_array.include?(element)
+        element_str = "**#{element}**"
+        element_str += ' (M)' if mandatory
+        "#{boolean_to_existent_string(resolve_path_with_dar(resource, element).first.present?,
+                                      optional: !mandatory)}: #{element_str}"
       end
       [title, result.join("\n\n")].join("\n\n")
     end

--- a/lib/au_ps_inferno/utils/composition_utils/boolean_and_stats.rb
+++ b/lib/au_ps_inferno/utils/composition_utils/boolean_and_stats.rb
@@ -2,8 +2,9 @@
 
 # Bundle-level booleans and per-path statistics lines for CompositionUtils.
 module CompositionUtilsBooleanAndStats
-  def boolean_to_existent_string(boolean_value)
-    boolean_value ? '✅ Populated' : '❌ Missing'
+  def boolean_to_existent_string(boolean_value, optional: false)
+    missing_icon = optional ? '⚠️' : '❌'
+    boolean_value ? '✅ Populated' : "#{missing_icon} Missing"
   end
 
   def all_entries_have_full_url_info?


### PR DESCRIPTION
## Fix labels for composition validation
Improves the visual formatting of composition validation messages to better distinguish between mandatory and optional missing elements, without changing any validation logic.

### Changes
- Missing mandatory elements continue to show ❌ Missing and now have an (M) marker appended to the element name.
- Missing optional elements now show ⚠️  Missing instead of ❌ Missing, making it clear they are not required.

**This distinction is applied consistently across:**
- Top-level composition elements (x.3.02)
- Composition sub-elements (e.g. attester fields in x.3.03)
- Composition slice elements (e.g. event fields in x.3.04)

Ref: https://github.com/hl7au/au-ps-inferno/issues/72