### PR TITLE
perf: set noEcosystem on tx.dev validator (work around tx-reg bug)

### DIFF
--- a/lib/au_ps_inferno/1.0.0-preview/100preview_suite.rb
+++ b/lib/au_ps_inferno/1.0.0-preview/100preview_suite.rb
@@ -22,6 +22,7 @@ module AUPSTestKit
 
       cli_context do
         txServer ENV.fetch('TX_SERVER_URL', 'https://tx.dev.hl7.org.au/fhir')
+        noEcosystem true
       end
     end
 

--- a/lib/au_ps_inferno/generator/templates/suite.rb.erb
+++ b/lib/au_ps_inferno/generator/templates/suite.rb.erb
@@ -16,6 +16,7 @@ module AUPSTestKit
 
       cli_context do
         txServer ENV.fetch('TX_SERVER_URL', 'https://tx.dev.hl7.org.au/fhir')
+        noEcosystem true
       end
     end
 

--- a/lib/au_ps_inferno/generator/templates/suite_primitive.rb.erb
+++ b/lib/au_ps_inferno/generator/templates/suite_primitive.rb.erb
@@ -16,6 +16,7 @@ module AUPSTestKit
 
       cli_context do
         txServer ENV.fetch('TX_SERVER_URL', 'https://tx.dev.hl7.org.au/fhir')
+        noEcosystem true
       end
     end
 


### PR DESCRIPTION
Mirrors the au-fhir-core-inferno performance fix for AU PS. Adds `noEcosystem true` to the suite's `fhir_resource_validator` `cli_context` so the validator skips the slow/buggy tx-registry ecosystem lookup against tx.dev.

Applied in **both** generator templates (`suite.rb.erb`, `suite_primitive.rb.erb`) **and** the generated `100preview_suite.rb`, so it stays correct on regeneration (the suite is byte-reproducible from the templates).

This is the prod (master) line. A matching PR targets the dev branch `improve-test-text-and-ui` so the fix lands on both dev and prod. Part of hl7au/au-fhir-inferno#68.

Validated: `ruby -c` on the generated suite passes.