### PR TITLE
Bump version to 1.0.0 for first stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.0.0] - 2026-07-29
+
+First stable release of the AU PS Inferno Test Kit, targeting AU PS Implementation Guide version 1.0.0. This release is functionally identical to 0.2.1; the version bump signals API and behaviour stability rather than new changes.
+
+### Summary of changes since 0.1.0
+
+- Bundle acquisition (pasted, retrieved from the FHIR server, or generated via `$summary`) is reported as its own test case, separate from Bundle Validation, so a failed retrieval no longer reads as a validation failure.
+- Each top-level test group validates only the Bundle it acquired itself, using a per-group scratch key, so a Bundle acquired in one group can no longer leak into and be validated by another.
+- Tests omit uniformly with one clear reason when a group's Bundle was not provided or acquired, instead of failing, passing vacuously, or skipping with inconsistent messages.
+- Direct-URL Bundle retrieval goes through the Inferno HTTP DSL instead of raw `Net::HTTP`, so the request appears in the Requests tab and configured auth headers are honoured.
+- The `$summary` acquisition test no longer skips when the server's CapabilityStatement omits the operation's declaration, since AU PS does not require it to be declared.
+- The gemspec packages `.tgz`, `.yml` and `.yaml` files under `lib/`, so the Implementation Guide package is included in the built gem.
+- The gem publishing workflow verifies the release tag matches the gem version, installs dependencies, and reliably builds and pushes the gem.
+
 ## [0.2.1] - 2026-07-21
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    au_ps_inferno (0.2.1)
+    au_ps_inferno (1.0.0)
       inferno_core (~> 1.0.6)
 
 GEM

--- a/lib/au_ps_inferno/version.rb
+++ b/lib/au_ps_inferno/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module AUPSTestKit
-  VERSION = '0.2.1'
+  VERSION = '1.0.0'
   IG_VERSION = '1.0.0'
 end


### PR DESCRIPTION
Promote the AU PS Inferno Test Kit to its first stable release, `1.0.0`, targeting AU PS Implementation Guide version 1.0.0.

This release is functionally identical to `0.2.1`. The version bump signals API and behaviour stability rather than new changes, pending sign-off at the report-out on 2026-07-29.

## Changes

- `lib/au_ps_inferno/version.rb`: `VERSION` bumped `0.2.1` to `1.0.0`.
- `Gemfile.lock`: `au_ps_inferno` locked version updated to `1.0.0`.
- `CHANGELOG.md`: added the `1.0.0` entry with a summary of changes accumulated since `0.1.0`.

## Release process

Do not merge until 0.2.1 is signed off. Once approved:

1. Merge this PR to `master`.
2. Publish the draft `v1.0.0` GitHub release, which fires `publish-gem.yaml` and pushes the gem to RubyGems.

The publish workflow verifies the release tag matches `AUPSTestKit::VERSION`, so the version bump must land on `master` before the release is published.