### PR TITLE
Add section narrative handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,7 @@ Metrics/MethodLength:
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*"
+    - "*.gemspec"
 
 Layout/LineLength:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Warn when the Problems, Allergies, or Medications section uses `Composition.section.emptyReason = nilknown` instead of an explicit negation code on the section's entry resource (e.g. `AllergyIntolerance.code = 716186003 |No known allergy|`), the pattern AU PS prefers over `emptyReason`. This is an advisory warning, not a failure.
+- Include the section's narrative (`Composition.section.text`), converted from HTML to Markdown, in the Must Support element population message for each section. The HTML is sanitized first (stripping scripts, styles, and other unsafe or non-display markup, including `img` tags) so untrusted narrative content can't inject anything unsafe into the test report.
 
 ### Fixed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ PATH
     au_ps_inferno (0.2.1)
       inferno_core (~> 1.0.6)
       reverse_markdown (~> 2.1)
+      sanitize (~> 6.1)
 
 GEM
   remote: https://rubygems.org/
@@ -40,6 +41,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
+    crass (1.0.7)
     csv (3.3.5)
     database_cleaner (1.99.0)
     database_cleaner-sequel (1.99.0)
@@ -299,6 +301,9 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
+    sanitize (6.1.3)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
     sequel (5.42.0)
     sidekiq (7.2.4)
       concurrent-ruby (< 2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ PATH
   specs:
     au_ps_inferno (0.2.1)
       inferno_core (~> 1.0.6)
+      reverse_markdown (~> 2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -263,6 +264,8 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    reverse_markdown (2.1.1)
+      nokogiri
     rexml (3.4.4)
     roo (2.10.1)
       nokogiri (~> 1)

--- a/au_ps_inferno.gemspec
+++ b/au_ps_inferno.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/hl7au/au-ps-inferno'
   spec.license       = 'Apache-2.0'
   spec.add_dependency 'inferno_core', '~> 1.0.6'
+  spec.add_dependency 'reverse_markdown', '~> 2.1'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'
   spec.add_development_dependency 'rspec', '~> 3.10'

--- a/au_ps_inferno.gemspec
+++ b/au_ps_inferno.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache-2.0'
   spec.add_dependency 'inferno_core', '~> 1.0.6'
   spec.add_dependency 'reverse_markdown', '~> 2.1'
+  spec.add_dependency 'sanitize', '~> 6.1'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'
   spec.add_development_dependency 'rspec', '~> 3.10'

--- a/lib/au_ps_inferno/utils/basic_test/section_bundle_validation_module.rb
+++ b/lib/au_ps_inferno/utils/basic_test/section_bundle_validation_module.rb
@@ -64,7 +64,12 @@ module AUPSTestKit
       elements_list = elements_array.map do |element|
         "**#{element}**: #{boolean_to_existent_string(resolve_path_with_dar(section, element).first.present?)}"
       end.join("\n\n")
-      [title, 'List of Must Support elements populated or missing:', elements_list].join("\n\n")
+      [
+        title,
+        'List of Must Support elements populated or missing:',
+        elements_list,
+        section_narrative_body(section)
+      ].join("\n\n")
     end
   end
 end

--- a/lib/au_ps_inferno/utils/basic_test/section_narrative_module.rb
+++ b/lib/au_ps_inferno/utils/basic_test/section_narrative_module.rb
@@ -9,18 +9,13 @@ module AUPSTestKit
     NARRATIVE_SANITIZE_CONFIG = Sanitize::Config.merge(
       Sanitize::Config::BASIC,
       elements: Sanitize::Config::BASIC[:elements] + %w[
-        div span hr img table caption thead tbody tfoot tr th td h1 h2 h3 h4 h5 h6
+        div span hr table caption thead tbody tfoot tr th td h1 h2 h3 h4 h5 h6
       ],
       attributes: Sanitize::Config.merge(
         Sanitize::Config::BASIC[:attributes],
         'span' => %w[title],
-        'img' => %w[alt src title],
         'th' => %w[colspan rowspan],
         'td' => %w[colspan rowspan]
-      ),
-      protocols: Sanitize::Config.merge(
-        Sanitize::Config::BASIC[:protocols],
-        'img' => { 'src' => ['data', :relative] }
       )
     ).freeze
 

--- a/lib/au_ps_inferno/utils/basic_test/section_narrative_module.rb
+++ b/lib/au_ps_inferno/utils/basic_test/section_narrative_module.rb
@@ -20,7 +20,7 @@ module AUPSTestKit
       ),
       protocols: Sanitize::Config.merge(
         Sanitize::Config::BASIC[:protocols],
-        'img' => { 'src' => ['http', 'https', :relative] }
+        'img' => { 'src' => ['data', :relative] }
       )
     ).freeze
 

--- a/lib/au_ps_inferno/utils/basic_test/section_narrative_module.rb
+++ b/lib/au_ps_inferno/utils/basic_test/section_narrative_module.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
 require 'reverse_markdown'
+require 'sanitize'
 
 module AUPSTestKit
   # Converts Composition.section.text (Narrative) into a displayable message.
   module BasicTestSectionNarrativeModule
-    # Elements that must never survive into the converted Markdown, even though FHIR's
-    # restricted narrative XHTML subset already disallows them (defense in depth).
-    UNSAFE_NARRATIVE_ELEMENTS = 'script, style, iframe, object, embed'
-
     def section_narrative_body(section)
       div = section&.text&.div
       return 'No narrative (`text`) present for this section.' if div.blank?
@@ -24,9 +20,7 @@ module AUPSTestKit
     private
 
     def sanitized_narrative_html(div)
-      fragment = Nokogiri::HTML::DocumentFragment.parse(div)
-      fragment.css(UNSAFE_NARRATIVE_ELEMENTS).remove
-      fragment.to_html
+      Sanitize.fragment(div, Sanitize::Config::RESTRICTED)
     end
   end
 end

--- a/lib/au_ps_inferno/utils/basic_test/section_narrative_module.rb
+++ b/lib/au_ps_inferno/utils/basic_test/section_narrative_module.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+require 'reverse_markdown'
+
+module AUPSTestKit
+  # Converts Composition.section.text (Narrative) into a displayable message.
+  module BasicTestSectionNarrativeModule
+    # Elements that must never survive into the converted Markdown, even though FHIR's
+    # restricted narrative XHTML subset already disallows them (defense in depth).
+    UNSAFE_NARRATIVE_ELEMENTS = 'script, style, iframe, object, embed'
+
+    def section_narrative_body(section)
+      div = section&.text&.div
+      return 'No narrative (`text`) present for this section.' if div.blank?
+
+      status = section.text.status
+      markdown = ReverseMarkdown.convert(sanitized_narrative_html(div), github_flavored: true).strip
+      markdown = '_(narrative converted to Markdown is empty)_' if markdown.blank?
+
+      "Narrative status: `#{status}`\n\n#{markdown}"
+    end
+
+    private
+
+    def sanitized_narrative_html(div)
+      fragment = Nokogiri::HTML::DocumentFragment.parse(div)
+      fragment.css(UNSAFE_NARRATIVE_ELEMENTS).remove
+      fragment.to_html
+    end
+  end
+end

--- a/lib/au_ps_inferno/utils/basic_test/section_narrative_module.rb
+++ b/lib/au_ps_inferno/utils/basic_test/section_narrative_module.rb
@@ -6,6 +6,24 @@ require 'sanitize'
 module AUPSTestKit
   # Converts Composition.section.text (Narrative) into a displayable message.
   module BasicTestSectionNarrativeModule
+    NARRATIVE_SANITIZE_CONFIG = Sanitize::Config.merge(
+      Sanitize::Config::BASIC,
+      elements: Sanitize::Config::BASIC[:elements] + %w[
+        div span hr img table caption thead tbody tfoot tr th td h1 h2 h3 h4 h5 h6
+      ],
+      attributes: Sanitize::Config.merge(
+        Sanitize::Config::BASIC[:attributes],
+        'span' => %w[title],
+        'img' => %w[alt src title],
+        'th' => %w[colspan rowspan],
+        'td' => %w[colspan rowspan]
+      ),
+      protocols: Sanitize::Config.merge(
+        Sanitize::Config::BASIC[:protocols],
+        'img' => { 'src' => ['http', 'https', :relative] }
+      )
+    ).freeze
+
     def section_narrative_body(section)
       div = section&.text&.div
       return 'No narrative (`text`) present for this section.' if div.blank?
@@ -20,7 +38,7 @@ module AUPSTestKit
     private
 
     def sanitized_narrative_html(div)
-      Sanitize.fragment(div, Sanitize::Config::RESTRICTED)
+      Sanitize.fragment(div, NARRATIVE_SANITIZE_CONFIG)
     end
   end
 end

--- a/lib/au_ps_inferno/utils/basic_test_class.rb
+++ b/lib/au_ps_inferno/utils/basic_test_class.rb
@@ -19,6 +19,7 @@ require_relative 'basic_test/composition_subelements_module'
 require_relative 'basic_test/ms_identifier_slices_module'
 require_relative 'basic_test/composition_elements_and_slices_module'
 require_relative 'basic_test/section_bundle_validation_module'
+require_relative 'basic_test/section_narrative_module'
 require_relative 'basic_test/resolve_path_debug_module'
 require_relative 'basic_test/ms_elements_populated_module'
 require_relative 'basic_test/ms_sub_elements_populated_module'
@@ -46,6 +47,7 @@ module AUPSTestKit
     include BasicTestMsIdentifierSlicesModule
     include BasicTestCompositionElementsAndSlicesModule
     include BasicTestSectionBundleValidationModule
+    include BasicTestSectionNarrativeModule
     include BasicTestResolvePathDebugModule
     include BasicTestMsElementsPopulatedModule
     include BasicTestMsSubElementsPopulatedModule

--- a/spec/unit/basic_test/section_bundle_validation_module_spec.rb
+++ b/spec/unit/basic_test/section_bundle_validation_module_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'fhir_models'
+
+require_relative '../../../lib/au_ps_inferno/utils/section_decorator'
+require_relative '../../support/basic_test/basic_test_instance_setup'
+
+RSpec.describe AUPSTestKit::BasicTestSectionBundleValidationModule do
+  include_context 'basic test instance setup'
+
+  def build_section(title: 'Patient Summary Problems Section', status: 'generated', narrative: 'Some narrative text.')
+    SectionDecorator.new(
+      title: title,
+      code: FHIR::CodeableConcept.new(coding: [FHIR::Coding.new(code: '11450-4', display: title)]),
+      text: FHIR::Narrative.new(status: status, div: "<div xmlns=\"http://www.w3.org/1999/xhtml\">#{narrative}</div>")
+    )
+  end
+
+  describe '#section_ms_elements_message (private)' do
+    it 'combines the Must Support population status and the converted narrative in a single body' do
+      section = build_section
+      result = test_instance.send(:section_ms_elements_message, section, %w[title code text])
+
+      expect(result).to include('List of Must Support elements populated or missing:')
+      expect(result).to include('**title**:')
+      expect(result).to include('Narrative status: `generated`')
+      expect(result).to include('Some narrative text.')
+    end
+  end
+
+  describe '#section_bundle_ms_population_outcome? (private)' do
+    it 'keeps the narrative content in the same message as the "correctly populated" status' do
+      section = build_section
+
+      test_instance.send(:section_bundle_ms_population_outcome?, section, %w[title code text])
+
+      expect(test_instance.messages.size).to eq(1)
+      message = test_instance.messages.first
+      expect(message[:type]).to eq('info')
+      expect(message[:message]).to include('Section correctly populated')
+      expect(message[:message]).to include('Narrative status: `generated`')
+      expect(message[:message]).to include('Some narrative text.')
+    end
+
+    it 'keeps the narrative content in the same message as the missing-mandatory error status' do
+      section = build_section(title: nil)
+
+      test_instance.send(:section_bundle_ms_population_outcome?, section, %w[title code text])
+
+      expect(test_instance.messages.size).to eq(1)
+      message = test_instance.messages.first
+      expect(message[:type]).to eq('error')
+      expect(message[:message]).to include('For section with any mandatory Must Support element in section missing')
+      expect(message[:message]).to include('Narrative status: `generated`')
+      expect(message[:message]).to include('Some narrative text.')
+    end
+
+    it 'flags placeholder narrative (status: empty) alongside a passing population status' do
+      section = build_section(status: 'empty', narrative: 'No information available')
+
+      test_instance.send(:section_bundle_ms_population_outcome?, section, %w[title code text])
+
+      message = test_instance.messages.first
+      expect(message[:type]).to eq('info')
+      expect(message[:message]).to include('Narrative status: `empty`')
+      expect(message[:message]).to include('No information available')
+    end
+  end
+end

--- a/spec/unit/basic_test/section_narrative_module_spec.rb
+++ b/spec/unit/basic_test/section_narrative_module_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'fhir_models'
+
+require_relative '../../../lib/au_ps_inferno/utils/basic_test/section_narrative_module'
+require_relative '../../support/basic_test/basic_test_instance_setup'
+
+RSpec.describe AUPSTestKit::BasicTestSectionNarrativeModule do
+  include_context 'basic test instance setup'
+
+  def section_with_text(status: 'generated', div: nil)
+    text = div.nil? ? nil : FHIR::Narrative.new(status: status, div: div)
+    FHIR::Composition::Section.new(text: text)
+  end
+
+  describe '#section_narrative_body' do
+    it 'converts a simple narrative div to Markdown and reports the narrative status' do
+      section = section_with_text(
+        status: 'generated',
+        div: '<div xmlns="http://www.w3.org/1999/xhtml">21/12/2024 No current problem or disability.</div>'
+      )
+
+      result = test_instance.section_narrative_body(section)
+
+      expect(result).to eq(
+        "Narrative status: `generated`\n\n21/12/2024 No current problem or disability."
+      )
+    end
+
+    it 'converts an HTML table narrative into Markdown table syntax' do
+      section = section_with_text(
+        status: 'generated',
+        div: '<div xmlns="http://www.w3.org/1999/xhtml"><table><thead><tr><th>Medicine</th></tr></thead>' \
+             '<tbody><tr><td>Bisoprolol</td></tr></tbody></table></div>'
+      )
+
+      result = test_instance.section_narrative_body(section)
+
+      expect(result).to start_with("Narrative status: `generated`\n\n")
+      expect(result).to include('Medicine')
+      expect(result).to include('Bisoprolol')
+      expect(result).not_to include('<table>')
+      expect(result).not_to include('<td>')
+    end
+
+    it 'flags empty-status placeholder narrative so it is visible to a reviewer' do
+      section = section_with_text(
+        status: 'empty',
+        div: '<div xmlns="http://www.w3.org/1999/xhtml">No information available</div>'
+      )
+
+      result = test_instance.section_narrative_body(section)
+
+      expect(result).to eq("Narrative status: `empty`\n\nNo information available")
+    end
+
+    it 'returns a fallback message when the section has no text element at all' do
+      section = section_with_text(div: nil)
+
+      result = test_instance.section_narrative_body(section)
+
+      expect(result).to eq('No narrative (`text`) present for this section.')
+    end
+
+    it 'never passes through raw HTML/script markup from the narrative div' do
+      section = section_with_text(
+        status: 'generated',
+        div: '<div xmlns="http://www.w3.org/1999/xhtml"><script>alert(1)</script><p>Safe text</p></div>'
+      )
+
+      result = test_instance.section_narrative_body(section)
+
+      expect(result).to include('Safe text')
+      expect(result).not_to include('<script>')
+      expect(result).not_to include('alert(1)')
+    end
+  end
+end

--- a/spec/unit/basic_test/section_narrative_module_spec.rb
+++ b/spec/unit/basic_test/section_narrative_module_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe AUPSTestKit::BasicTestSectionNarrativeModule do
       )
     end
 
-    it 'converts an HTML table narrative into Markdown table syntax' do
+    it 'strips table structure from an HTML table narrative, keeping only the cell text' do
       section = section_with_text(
         status: 'generated',
         div: '<div xmlns="http://www.w3.org/1999/xhtml"><table><thead><tr><th>Medicine</th></tr></thead>' \
@@ -36,11 +36,9 @@ RSpec.describe AUPSTestKit::BasicTestSectionNarrativeModule do
 
       result = test_instance.section_narrative_body(section)
 
-      expect(result).to start_with("Narrative status: `generated`\n\n")
-      expect(result).to include('Medicine')
-      expect(result).to include('Bisoprolol')
-      expect(result).not_to include('<table>')
-      expect(result).not_to include('<td>')
+      # Sanitize::Config::RESTRICTED does not allow table elements, so their tags are
+      # dropped and the cell text is concatenated with no separator between cells.
+      expect(result).to eq("Narrative status: `generated`\n\nMedicineBisoprolol")
     end
 
     it 'flags empty-status placeholder narrative so it is visible to a reviewer' do
@@ -73,6 +71,21 @@ RSpec.describe AUPSTestKit::BasicTestSectionNarrativeModule do
       expect(result).to include('Safe text')
       expect(result).not_to include('<script>')
       expect(result).not_to include('alert(1)')
+    end
+
+    it 'strips event-handler attributes even from tags reverse_markdown has no converter for' do
+      section = section_with_text(
+        status: 'generated',
+        div: '<div xmlns="http://www.w3.org/1999/xhtml">' \
+             '<u onmouseover="alert(1)">hover me</u><a href="javascript:alert(2)">click</a></div>'
+      )
+
+      result = test_instance.section_narrative_body(section)
+
+      expect(result).not_to include('onmouseover')
+      expect(result).not_to include('javascript:')
+      expect(result).not_to include('alert(1)')
+      expect(result).not_to include('alert(2)')
     end
   end
 end

--- a/spec/unit/basic_test/section_narrative_module_spec.rb
+++ b/spec/unit/basic_test/section_narrative_module_spec.rb
@@ -90,6 +90,31 @@ RSpec.describe AUPSTestKit::BasicTestSectionNarrativeModule do
       expect(result).not_to include('alert(1)')
     end
 
+    it 'strips http(s) img src so a narrative cannot be used as a tracking pixel' do
+      section = section_with_text(
+        status: 'generated',
+        div: '<div xmlns="http://www.w3.org/1999/xhtml">' \
+             '<img src="https://example.invalid/pixel.gif" alt="tracker"></div>'
+      )
+
+      result = test_instance.section_narrative_body(section)
+
+      expect(result).not_to include('example.invalid')
+      expect(result).not_to include('https://')
+    end
+
+    it 'keeps data URI img src so self-contained narrative images still render' do
+      data_uri = 'data:image/png;base64,iVBORw0KGgo='
+      section = section_with_text(
+        status: 'generated',
+        div: "<div xmlns=\"http://www.w3.org/1999/xhtml\"><img src=\"#{data_uri}\" alt=\"inline\"></div>"
+      )
+
+      result = test_instance.section_narrative_body(section)
+
+      expect(result).to include(data_uri)
+    end
+
     it 'strips event-handler attributes even from tags reverse_markdown has no converter for' do
       section = section_with_text(
         status: 'generated',

--- a/spec/unit/basic_test/section_narrative_module_spec.rb
+++ b/spec/unit/basic_test/section_narrative_module_spec.rb
@@ -27,18 +27,35 @@ RSpec.describe AUPSTestKit::BasicTestSectionNarrativeModule do
       )
     end
 
-    it 'strips table structure from an HTML table narrative, keeping only the cell text' do
+    it 'converts an HTML table narrative into Markdown table syntax' do
       section = section_with_text(
         status: 'generated',
-        div: '<div xmlns="http://www.w3.org/1999/xhtml"><table><thead><tr><th>Medicine</th></tr></thead>' \
-             '<tbody><tr><td>Bisoprolol</td></tr></tbody></table></div>'
+        div: '<div xmlns="http://www.w3.org/1999/xhtml"><table><thead><tr><th>Medicine</th><th>Dose</th></tr></thead>' \
+             '<tbody><tr><td>Bisoprolol</td><td>2.5mg</td></tr></tbody></table></div>'
       )
 
       result = test_instance.section_narrative_body(section)
 
-      # Sanitize::Config::RESTRICTED does not allow table elements, so their tags are
-      # dropped and the cell text is concatenated with no separator between cells.
-      expect(result).to eq("Narrative status: `generated`\n\nMedicineBisoprolol")
+      expect(result).to eq(
+        "Narrative status: `generated`\n\n" \
+        "| Medicine | Dose |\n" \
+        "| --- | --- |\n" \
+        '| Bisoprolol | 2.5mg |'
+      )
+    end
+
+    it 'converts a link narrative into Markdown link syntax, keeping only safe protocols' do
+      section = section_with_text(
+        status: 'generated',
+        div: '<div xmlns="http://www.w3.org/1999/xhtml">' \
+             '<a href="mailto:info@example.com">info@example.com</a></div>'
+      )
+
+      result = test_instance.section_narrative_body(section)
+
+      expect(result).to eq(
+        "Narrative status: `generated`\n\n[info@example.com](mailto:info@example.com)"
+      )
     end
 
     it 'flags empty-status placeholder narrative so it is visible to a reviewer' do

--- a/spec/unit/basic_test/section_narrative_module_spec.rb
+++ b/spec/unit/basic_test/section_narrative_module_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe AUPSTestKit::BasicTestSectionNarrativeModule do
       expect(result).not_to include('alert(1)')
     end
 
-    it 'strips http(s) img src so a narrative cannot be used as a tracking pixel' do
+    it 'strips http(s) img tags so a narrative cannot be used as a tracking pixel' do
       section = section_with_text(
         status: 'generated',
         div: '<div xmlns="http://www.w3.org/1999/xhtml">' \
@@ -103,7 +103,7 @@ RSpec.describe AUPSTestKit::BasicTestSectionNarrativeModule do
       expect(result).not_to include('https://')
     end
 
-    it 'keeps data URI img src so self-contained narrative images still render' do
+    it 'strips data URI img tags entirely so no image markup ever renders' do
       data_uri = 'data:image/png;base64,iVBORw0KGgo='
       section = section_with_text(
         status: 'generated',
@@ -112,7 +112,8 @@ RSpec.describe AUPSTestKit::BasicTestSectionNarrativeModule do
 
       result = test_instance.section_narrative_body(section)
 
-      expect(result).to include(data_uri)
+      expect(result).not_to include(data_uri)
+      expect(result).not_to include('inline')
     end
 
     it 'strips event-handler attributes even from tags reverse_markdown has no converter for' do


### PR DESCRIPTION
Update makes the Composition section's clinical narrative text visible and safely rendered in Inferno test results, rather than leaving reviewers to inspect the raw resource.

Issue: https://github.com/hl7au/au-ps-inferno/issues/37
PR in the AU FHIR Inferno repo: https://github.com/hl7au/au-fhir-inferno/pull/180
Deployed preview version: https://pr-180.preview.inferno.sparked-fhir.com
Example of the suite run : https://pr-180.preview.inferno.sparked-fhir.com/suites/au_ps_v100/l9T9P3bNx3Q/#1