### PR TITLE
Select the Australian SNOMED CT edition for validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Select the Australian SNOMED CT edition for validation instead of the validator's International default. The AU terminology server carries only the Australian edition, so the default made every SNOMED lookup fail and caused valid codes to be reported as absent from their value sets. Validating the AU PS `aups-basicsummary` example against `tx.dev.hl7.org.au` drops from 28 warnings and 19 information messages to 8 and 9, and removes a spurious error on the contained Medication's AMT code. Override with the `SNOMED_EDITION` environment variable.
+
 ## [1.0.0] - 2026-07-29
 
 First stable release of the AU PS Inferno Test Kit, targeting AU PS Implementation Guide version 1.0.0. This release is functionally identical to 0.2.1; the version bump signals API and behaviour stability rather than new changes.

--- a/lib/au_ps_inferno/suite/au_ps_v100.rb
+++ b/lib/au_ps_inferno/suite/au_ps_v100.rb
@@ -24,6 +24,18 @@ module AUPSTestKit
 
       cli_context do
         txServer ENV.fetch('TX_SERVER_URL', 'https://tx.dev.hl7.org.au/fhir')
+        # The validator defaults snomedCT to the International edition
+        # (900000000000207008) and turns it into an expansion parameter
+        # "system-version=http://snomed.info/sct|http://snomed.info/sct/<edition>".
+        # The AU terminology server carries only the Australian edition, so the
+        # default makes every SNOMED lookup fail with "A definition for CodeSystem
+        # 'http://snomed.info/sct' version 'null' could not be found", and the
+        # validator then reports valid codes as absent from their value sets.
+        # The AU edition is a derivative containing the full International release
+        # plus the AU extension and AMT, so nothing is lost by selecting it, and
+        # AMT codes (required binding on AU Core Medication.code.coding:amt) are
+        # only resolvable here.
+        snomedCT ENV.fetch('SNOMED_EDITION', 'au')
         noEcosystem true
       end
     end

--- a/spec/unit/suite_structure_spec.rb
+++ b/spec/unit/suite_structure_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe 'AU PS suite structure' do
     expect(suite.groups.length).to eq(4)
   end
 
+  it 'pins the validator to the Australian SNOMED CT edition' do
+    definition = suite.fhir_validators[:default].first.validation_context.definition
+
+    expect(definition[:snomedCT]).to eq('au')
+  end
+
   it 'starts the instance group with the load test, followed by Bundle Validation' do
     group = top_level_group('au_ps_bundle_instance')
     expect(group.children.first.title).to eq('Provide AU PS Bundle')


### PR DESCRIPTION
## Problem

The suite leaves `cliContext.snomedCT` at the validator's default, the SNOMED **International** edition (`900000000000207008`). `ValidationEngine.setSnomedExtension` turns that into an expansion parameter:

```
system-version = http://snomed.info/sct|http://snomed.info/sct/900000000000207008
```

`tx.dev.hl7.org.au` carries only the **Australian** edition, so every SNOMED lookup fails with:

```
A definition for CodeSystem 'http://snomed.info/sct' version 'null' could not be found,
so the code cannot be validated. Valid versions: [.../32506021000036107/version/...]
```

The validator then reports valid codes as absent from their value sets. Querying the terminology server directly confirms every flagged code is a member of the value set it was reported as missing from, including `782415009`, `1269424006`, `373568007` (indicator-hypersensitivity-intolerance-to-substance-2), `160245001` (clinical-condition-1), `288565001` (healthcare-organisation-role-type-1), `62247001` (practitioner-role-1), and `446141000124107` (gender-identity-response-1, the target of the `inv-pat-1` invariant).

## Fix

Select the Australian edition. It is a derivative containing the full International release plus the AU extension and AMT, so nothing is lost. It also resolves AMT codes such as `23281011000036106` (module `32506021000036107`), which carry a required binding on AU Core `Medication.code.coding:amt` and exist in no other edition. Loading International alongside would not help and would make that binding fail legitimately.

`SNOMED_EDITION` overrides it, matching the existing `TX_SERVER_URL` treatment.

## Verification

The AU PS `aups-basicsummary` example validated against `tx.dev.hl7.org.au`:

| validator-wrapper | before | after |
|---|---|---|
| 1.0.78 (core 6.9.7) | 28 warnings / 19 info | **8 / 9** |
| 1.0.81 (core 6.9.12) | 28 warnings / 19 info | **8 / 9** |

A spurious `error` on the contained Medication (`Unable to find a profile match for #bisoprolol`) is also removed. The remaining 8 warnings are genuine and unrelated: four `Found multiple matching profiles` from AU Base listing base `Identifier`/`Address` alongside the specialised profiles, and three duplicate reports that `v2-0203#EI` is absent from the R4 `identifier-type` value set.

## Deploying this

Inferno persists validator session ids in `validator_sessions`, keyed on `(test_suite_id, suite_options, validator_name)` only, never on context content. The validator wrapper binds an engine to its session and **ignores a changed `cliContext`** for an existing session id. Confirmed by replaying the same bundle with the new context against an existing session: unchanged at 28/19, while a fresh session gives 8/9. Deployments must therefore clear `validator_sessions` (and restart the validator) for this to take effect.