### PR TITLE
Implement address country validation and metadata extraction for AU profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Warn when `Address.country` on a Patient, Practitioner, RelatedPerson, or Organization resource doesn't match the `au-address` fixed code `"AU"` (e.g. `"Australia"`, `"AUS"`) (#35).
+
 ### Fixed
 
 - Select the Australian SNOMED CT edition for validation instead of the validator's International default. The AU terminology server carries only the Australian edition, so the default made every SNOMED lookup fail and caused valid codes to be reported as absent from their value sets. Validating the AU PS `aups-basicsummary` example against `tx.dev.hl7.org.au` drops from 28 warnings and 19 information messages to 8 and 9, and removes a spurious error on the contained Medication's AMT code. Override with the `SNOMED_EDITION` environment variable.

--- a/lib/au_ps_inferno/generator/metadata_manager.rb
+++ b/lib/au_ps_inferno/generator/metadata_manager.rb
@@ -51,6 +51,8 @@ class Generator
       'Patient|http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-patient'
     ].freeze
 
+    AU_ADDRESS_PROFILE_URL = 'http://hl7.org.au/fhir/StructureDefinition/au-address'
+
     # Initializes a MetadataManager for the given IG resources.
     #
     # @param ig_resources [Array<FHIR::Model>] Parsed IG resources (e.g. from IGResourcesExtractor#ig_resources)
@@ -59,6 +61,7 @@ class Generator
       reset_composition_metadata_ivars!
     end
 
+    # rubocop:disable Metrics/MethodLength
     def reset_composition_metadata_ivars!
       @composition_sections = []
       @composition_mandatory_ms_elements = []
@@ -70,7 +73,9 @@ class Generator
       @profiles = []
       @resources_filters = {}
       @normalized_sections_data = []
+      @address_profile_elements = []
     end
+    # rubocop:enable Metrics/MethodLength
 
     # Generates composition section metadata from IG resources (in-memory only).
     # Populates the internal composition sections and related metadata used by {#save_to_file}.
@@ -82,6 +87,7 @@ class Generator
       extract_optional_ms_elements
       extract_profiles
       extract_resource_filters
+      extract_address_profile_elements
       normalize_sections_data
     end
 
@@ -128,8 +134,25 @@ class Generator
     def metadata_dump_tail
       {
         profiles: @profiles,
-        resources_filters: @resources_filters
+        resources_filters: @resources_filters,
+        address_profile_elements: @address_profile_elements
       }
+    end
+
+    def extract_address_profile_elements
+      @address_profile_elements = main_profiles.flat_map { |sd| address_profile_elements_for(sd) }
+    end
+
+    def address_profile_elements_for(structure_definition)
+      structure_definition.snapshot.element.select { |element| au_address_typed?(element) }.map do |element|
+        { resource_type: structure_definition.type, path: element.path.gsub("#{structure_definition.type}.", '') }
+      end
+    end
+
+    def au_address_typed?(element)
+      (element.type || []).any? do |type|
+        type.code == 'Address' && (type.profile || []).include?(AU_ADDRESS_PROFILE_URL)
+      end
     end
 
     def normalize_section_data(section_id)

--- a/lib/au_ps_inferno/metadata.yaml
+++ b/lib/au_ps_inferno/metadata.yaml
@@ -1364,6 +1364,17 @@
   :filters:
   - path: code.coding.code
     value: 74013-4
+:address_profile_elements:
+- :resource_type: Organization
+  :path: address
+- :resource_type: Patient
+  :path: address
+- :resource_type: Patient
+  :path: contact.address
+- :resource_type: Practitioner
+  :path: address
+- :resource_type: RelatedPerson
+  :path: address
 :ig_id: hl7.fhir.au.ps
 :ig_title: AU PS
 :ig_module_name_prefix: AUPS

--- a/lib/au_ps_inferno/suite/au_ps_v100.rb
+++ b/lib/au_ps_inferno/suite/au_ps_v100.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../version'
+require_relative '../utils/address_country_check'
 
 require_relative 'au_ps_bundle_instance/au_ps_bundle_instance'
 
@@ -21,6 +22,10 @@ module AUPSTestKit
 
     fhir_resource_validator do
       igs "hl7.fhir.au.ps##{AUPSTestKit::IG_VERSION}"
+
+      perform_additional_validation do |resource, _profile_url|
+        AUPSTestKit::AddressCountryCheck.messages_for(resource)
+      end
 
       cli_context do
         txServer ENV.fetch('TX_SERVER_URL', 'https://tx.dev.hl7.org.au/fhir')

--- a/lib/au_ps_inferno/utils/address_country_check.rb
+++ b/lib/au_ps_inferno/utils/address_country_check.rb
@@ -32,22 +32,28 @@ module AUPSTestKit
     end
 
     def incorrect_country_messages(resource, path)
-      addresses_at_path(resource, path).each_with_index.filter_map do |address, idx|
+      addresses_at_path(resource, path).filter_map do |address, indexed_path|
         country = address&.country
         next if country.blank? || country == AU_COUNTRY_CODE
 
-        { type: 'warning', message: incorrect_country_message(resource, path, idx, country) }
+        { type: 'warning', message: incorrect_country_message(resource, indexed_path, country) }
       end
     end
 
     def addresses_at_path(resource, path)
-      path.split('.').inject([resource]) do |nodes, segment|
-        nodes.flat_map { |node| node.respond_to?(segment) ? Array(node.public_send(segment)) : [] }
+      path.split('.').inject([[resource, '']]) do |nodes, segment|
+        nodes.flat_map do |node, prefix|
+          next [] unless node.respond_to?(segment)
+
+          Array(node.public_send(segment)).each_with_index.map do |child, idx|
+            [child, prefix.empty? ? "#{segment}[#{idx}]" : "#{prefix}.#{segment}[#{idx}]"]
+          end
+        end
       end
     end
 
-    def incorrect_country_message(resource, path, idx, country)
-      "#{resource.resourceType}/#{resource.id}: #{path}[#{idx}].country = \"#{country}\" does " \
+    def incorrect_country_message(resource, indexed_path, country)
+      "#{resource.resourceType}/#{resource.id}: #{indexed_path}.country = \"#{country}\" does " \
         'not match the au-address fixed code "AU".'
     end
   end

--- a/lib/au_ps_inferno/utils/address_country_check.rb
+++ b/lib/au_ps_inferno/utils/address_country_check.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative 'metadata_manager'
+
+module AUPSTestKit
+  # Flags Address.country values that don't match the au-address fixed code "AU"
+  module AddressCountryCheck
+    AU_COUNTRY_CODE = 'AU'
+    METADATA_PATH = File.expand_path('../metadata.yaml', __dir__)
+
+    module_function
+
+    def address_paths_by_resource_type
+      @address_paths_by_resource_type ||=
+        MetadataManager.new(METADATA_PATH).address_profile_elements.each_with_object({}) do |element, paths|
+          (paths[element[:resource_type]] ||= []) << element[:path]
+        end
+    end
+
+    def messages_for(resource)
+      return [] unless resource.is_a?(FHIR::Bundle)
+
+      resource.entry.flat_map { |entry| messages_for_entry(entry) }
+    end
+
+    def messages_for_entry(entry)
+      candidate = entry&.resource
+      paths = candidate && address_paths_by_resource_type[candidate.resourceType]
+      return [] if paths.blank?
+
+      paths.flat_map { |path| incorrect_country_messages(candidate, path) }
+    end
+
+    def incorrect_country_messages(resource, path)
+      addresses_at_path(resource, path).each_with_index.filter_map do |address, idx|
+        country = address&.country
+        next if country.blank? || country == AU_COUNTRY_CODE
+
+        { type: 'warning', message: incorrect_country_message(resource, path, idx, country) }
+      end
+    end
+
+    def addresses_at_path(resource, path)
+      path.split('.').inject([resource]) do |nodes, segment|
+        nodes.flat_map { |node| node.respond_to?(segment) ? Array(node.public_send(segment)) : [] }
+      end
+    end
+
+    def incorrect_country_message(resource, path, idx, country)
+      "#{resource.resourceType}/#{resource.id}: #{path}[#{idx}].country = \"#{country}\" does " \
+        'not match the au-address fixed code "AU".'
+    end
+  end
+end

--- a/lib/au_ps_inferno/utils/metadata_manager.rb
+++ b/lib/au_ps_inferno/utils/metadata_manager.rb
@@ -58,9 +58,5 @@ module AUPSTestKit
     def address_profile_elements
       metadata[:address_profile_elements] || []
     end
-
-    def address_profile_resource_types
-      address_profile_elements.map { |element| element[:resource_type] }.uniq
-    end
   end
 end

--- a/lib/au_ps_inferno/utils/metadata_manager.rb
+++ b/lib/au_ps_inferno/utils/metadata_manager.rb
@@ -54,5 +54,13 @@ module AUPSTestKit
     def groups_metadata
       metadata[:groups]
     end
+
+    def address_profile_elements
+      metadata[:address_profile_elements] || []
+    end
+
+    def address_profile_resource_types
+      address_profile_elements.map { |element| element[:resource_type] }.uniq
+    end
   end
 end

--- a/spec/generator/metadata_manager_address_profile_elements_spec.rb
+++ b/spec/generator/metadata_manager_address_profile_elements_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'fhir_models'
+
+require_relative '../../lib/au_ps_inferno/generator/metadata_manager'
+
+RSpec.describe Generator::MetadataManager do
+  def structure_definition(type:, elements:)
+    FHIR::StructureDefinition.new(
+      resourceType: 'StructureDefinition',
+      url: "http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-#{type.downcase}",
+      type: type,
+      snapshot: { element: elements }
+    )
+  end
+
+  def address_element(path, profiles)
+    { id: path, path: path, type: [{ code: 'Address', profile: profiles }] }
+  end
+
+  describe '#extract_address_profile_elements' do
+    it 'captures every resource type/path whose Address element is constrained by au-address' do
+      sd = structure_definition(
+        type: 'Patient',
+        elements: [
+          address_element('Patient.address', ['http://hl7.org.au/fhir/StructureDefinition/au-address']),
+          address_element('Patient.contact.address', ['http://hl7.org.au/fhir/StructureDefinition/au-address'])
+        ]
+      )
+
+      manager = described_class.new([sd])
+
+      expect(manager.extract_address_profile_elements).to contain_exactly(
+        { resource_type: 'Patient', path: 'address' },
+        { resource_type: 'Patient', path: 'contact.address' }
+      )
+    end
+
+    it 'excludes Address-typed elements not constrained by the au-address profile' do
+      sd = structure_definition(
+        type: 'Location',
+        elements: [
+          address_element('Location.address', ['http://hl7.org/fhir/StructureDefinition/Address'])
+        ]
+      )
+
+      manager = described_class.new([sd])
+
+      expect(manager.extract_address_profile_elements).to eq([])
+    end
+
+    it 'excludes elements that are not typed Address at all' do
+      sd = structure_definition(
+        type: 'Patient',
+        elements: [
+          { id: 'Patient.name', path: 'Patient.name', type: [{ code: 'HumanName' }] }
+        ]
+      )
+
+      manager = described_class.new([sd])
+
+      expect(manager.extract_address_profile_elements).to eq([])
+    end
+  end
+end

--- a/spec/unit/address_country_check_spec.rb
+++ b/spec/unit/address_country_check_spec.rb
@@ -82,7 +82,24 @@ RSpec.describe AUPSTestKit::AddressCountryCheck do
     messages = described_class.messages_for(bundle)
 
     expect(messages.length).to eq(1)
-    expect(messages.first[:message]).to include('contact.address[0]')
+    expect(messages.first[:message]).to include('contact[0].address[0]')
+  end
+
+  it 'references the correct per-segment index for a nested path with multiple contacts' do
+    patient = FHIR::Patient.new(
+      resourceType: 'Patient',
+      id: 'p1',
+      contact: [
+        { address: { country: 'AU' } },
+        { address: { country: 'Australia' } }
+      ]
+    )
+    bundle = bundle_with(patient)
+
+    messages = described_class.messages_for(bundle)
+
+    expect(messages.length).to eq(1)
+    expect(messages.first[:message]).to include('contact[1].address[0]')
   end
 
   it 'covers more than one resource type, not just Patient' do

--- a/spec/unit/address_country_check_spec.rb
+++ b/spec/unit/address_country_check_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'fhir_models'
+
+require_relative '../../lib/au_ps_inferno/utils/address_country_check'
+
+RSpec.describe AUPSTestKit::AddressCountryCheck do
+  # Stub the metadata-derived paths directly so the spec doesn't depend on (or drift with)
+  # the real generated metadata.yaml.
+  before do
+    described_class.instance_variable_set(:@address_paths_by_resource_type,
+                                          { 'Patient' => %w[address contact.address],
+                                            'Organization' => ['address'] })
+  end
+
+  after do
+    described_class.instance_variable_set(:@address_paths_by_resource_type, nil)
+  end
+
+  def bundle_with(*resources)
+    FHIR::Bundle.new(
+      resourceType: 'Bundle',
+      type: 'document',
+      entry: resources.map { |resource| { fullUrl: "urn:uuid:#{resource.id}", resource: resource } }
+    )
+  end
+
+  def patient_with_address(id:, country:)
+    FHIR::Patient.new(resourceType: 'Patient', id: id, address: [{ country: country }])
+  end
+
+  it 'returns no messages when every address country is "AU"' do
+    bundle = bundle_with(patient_with_address(id: 'p1', country: 'AU'))
+
+    expect(described_class.messages_for(bundle)).to eq([])
+  end
+
+  it 'returns no messages when country is absent' do
+    bundle = bundle_with(FHIR::Patient.new(resourceType: 'Patient', id: 'p1', address: [{ city: 'Sydney' }]))
+
+    expect(described_class.messages_for(bundle)).to eq([])
+  end
+
+  it 'warns when country is a full country name' do
+    bundle = bundle_with(patient_with_address(id: 'p1', country: 'Australia'))
+
+    messages = described_class.messages_for(bundle)
+
+    expect(messages.length).to eq(1)
+    expect(messages.first[:type]).to eq('warning')
+    expect(messages.first[:message]).to include('Patient/p1').and include('"Australia"')
+  end
+
+  it 'warns when country is the alpha-3 code' do
+    bundle = bundle_with(patient_with_address(id: 'p1', country: 'AUS'))
+
+    expect(described_class.messages_for(bundle).length).to eq(1)
+  end
+
+  it 'warns once per offending address, referencing the correct index' do
+    patient = FHIR::Patient.new(
+      resourceType: 'Patient',
+      id: 'p1',
+      address: [{ country: 'AU' }, { country: 'Australia' }]
+    )
+    bundle = bundle_with(patient)
+
+    messages = described_class.messages_for(bundle)
+
+    expect(messages.length).to eq(1)
+    expect(messages.first[:message]).to include('address[1]')
+  end
+
+  it 'walks nested paths from metadata (e.g. Patient.contact.address)' do
+    patient = FHIR::Patient.new(
+      resourceType: 'Patient',
+      id: 'p1',
+      contact: [{ address: { country: 'Australia' } }]
+    )
+    bundle = bundle_with(patient)
+
+    messages = described_class.messages_for(bundle)
+
+    expect(messages.length).to eq(1)
+    expect(messages.first[:message]).to include('contact.address[0]')
+  end
+
+  it 'covers more than one resource type, not just Patient' do
+    organization = FHIR::Organization.new(resourceType: 'Organization', id: 'org1', address: [{ country: 'AUS' }])
+    bundle = bundle_with(organization)
+
+    messages = described_class.messages_for(bundle)
+
+    expect(messages.length).to eq(1)
+    expect(messages.first[:message]).to include('Organization/org1')
+  end
+
+  it 'returns no messages for a resource type not covered by au-address metadata' do
+    practitioner = FHIR::Practitioner.new(resourceType: 'Practitioner', id: 'pr1', address: [{ country: 'Australia' }])
+    bundle = bundle_with(practitioner)
+
+    expect(described_class.messages_for(bundle)).to eq([])
+  end
+
+  it 'returns no messages for a non-Bundle resource' do
+    patient = patient_with_address(id: 'p1', country: 'Australia')
+
+    expect(described_class.messages_for(patient)).to eq([])
+  end
+end


### PR DESCRIPTION
This adds a mechanism to validate address.country 

Issue: https://github.com/hl7au/au-ps-inferno/issues/35
PR in the AU FHIR Inferno repo: https://github.com/hl7au/au-fhir-inferno/pull/185
Deployed preview version: https://pr-185.preview.inferno.sparked-fhir.com/
Example of the suite run with CORRECT address.country: https://pr-185.preview.inferno.sparked-fhir.com/suites/au_ps_v100/34hkDq0NG8f/#1
Example of the suite run with INCORRECT address.country: https://pr-185.preview.inferno.sparked-fhir.com/suites/au_ps_v100/hOYztJM2Xt9/#1