### PR TITLE
Add section negation checks and related tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Warn when the Problems, Allergies, or Medications section uses `Composition.section.emptyReason = nilknown` instead of an explicit negation code on the section's entry resource (e.g. `AllergyIntolerance.code = 716186003 |No known allergy|`), the pattern AU PS prefers over `emptyReason`. This is an advisory warning, not a failure.
+
 ### Fixed
 
 - Select the Australian SNOMED CT edition for validation instead of the validator's International default. The AU terminology server carries only the Australian edition, so the default made every SNOMED lookup fail and caused valid codes to be reported as absent from their value sets. Validating the AU PS `aups-basicsummary` example against `tx.dev.hl7.org.au` drops from 28 warnings and 19 information messages to 8 and 9, and removes a spurious error on the contained Medication's AMT code. Override with the `SNOMED_EDITION` environment variable.

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ snapshot-tests-update:
 rubocop:
 	$(compose) $(inferno) rubocop
 
+rubocop_fix:
+	$(compose) $(inferno) rubocop -A
+
 rake_generate:
 	$(compose) $(inferno) bundle exec rake generator:generate
 

--- a/lib/au_ps_inferno/suite/au_ps_bundle_instance/au_ps_composition_mandatory_sections.rb
+++ b/lib/au_ps_inferno/suite/au_ps_bundle_instance/au_ps_composition_mandatory_sections.rb
@@ -4,6 +4,8 @@ require_relative 'au_ps_composition_mandatory_sections/suite_au_ps_bundle_instan
 
 require_relative 'au_ps_composition_mandatory_sections/composition_mandatory_sections_mandatory_sections_entry_profiles'
 
+require_relative 'au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning'
+
 module AUPSTestKit
   # Automatically generated primitive group for AU PS Composition Mandatory Sections
   class AUPSSuiteAuPsBundleInstanceAuPsCompositionMandatorySections < Inferno::TestGroup
@@ -16,5 +18,7 @@ module AUPSTestKit
     test from: :suite_au_ps_bundle_instance_au_ps_composition_mandatory_sections_sections_shall_populated
 
     test from: :suite_au_ps_bundle_instance_au_ps_composition_mandatory_sections_mandatory_sections_entry_profiles
+
+    test from: :suite_au_ps_bundle_instance_au_ps_composition_mandatory_sections_nilknown_warning
   end
 end

--- a/lib/au_ps_inferno/suite/au_ps_bundle_instance/au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning.rb
+++ b/lib/au_ps_inferno/suite/au_ps_bundle_instance/au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning.rb
@@ -14,7 +14,7 @@ module AUPSTestKit
     id :suite_au_ps_bundle_instance_au_ps_composition_mandatory_sections_nilknown_warning
 
     run do
-      warn_on_nilknown_empty_reason(%w[11450-4 48765-2 10160-0])
+      warn_on_nilknown_empty_reason(MANDATORY_SECTIONS_CODES)
     end
   end
 end

--- a/lib/au_ps_inferno/suite/au_ps_bundle_instance/au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning.rb
+++ b/lib/au_ps_inferno/suite/au_ps_bundle_instance/au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../../../utils/basic_test_class'
+
+module AUPSTestKit
+  # Warns against using emptyReason=nilknown instead of an explicit negation entry
+  class AUPSSuiteAuPsBundleInstanceAuPsCompositionMandatorySectionsNilknownWarning < BasicTest
+    title 'AU PS Composition Mandatory Sections do not rely on emptyReason=nilknown'
+    description 'Warns when a mandatory section (Problems, Allergies, Medications) uses ' \
+                 'Composition.section.emptyReason = nilknown instead of an explicit negation code on the ' \
+                 "section's entry resource (e.g. AllergyIntolerance.code = 716186003 |No known allergy|). " \
+                 'AU PS prefers the explicit-entry pattern used by FHIR, IPS and AU Core over emptyReason ' \
+                 '- this is a warning, not a failure.'
+    id :suite_au_ps_bundle_instance_au_ps_composition_mandatory_sections_nilknown_warning
+
+    run do
+      warn_on_nilknown_empty_reason(%w[11450-4 48765-2 10160-0])
+    end
+  end
+end

--- a/lib/au_ps_inferno/suite/generate_au_ps_using_ips_summary_validation_tests/au_ps_composition_mandatory_sections.rb
+++ b/lib/au_ps_inferno/suite/generate_au_ps_using_ips_summary_validation_tests/au_ps_composition_mandatory_sections.rb
@@ -4,6 +4,8 @@ require_relative 'au_ps_composition_mandatory_sections/composition_mandatory_sec
 
 require_relative 'au_ps_composition_mandatory_sections/composition_mandatory_sections_mandatory_sections_entry_profiles'
 
+require_relative 'au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning'
+
 module AUPSTestKit
   # Automatically generated primitive group for AU PS Composition Mandatory Sections
   class AUPSSuiteGenerateAuPsUsingIpsSummaryValidationTestsAuPsCompositionMandatorySections < Inferno::TestGroup
@@ -16,5 +18,7 @@ module AUPSTestKit
     test from: :suite_generate_au_ps_using_ips_summary_validation_tests_au_ps_composition_mandatory_sections_sections_shall_populated
 
     test from: :suite_generate_au_ps_using_ips_summary_validation_tests_au_ps_composition_mandatory_sections_mandatory_sections_entry_profiles
+
+    test from: :suite_generate_au_ps_using_ips_summary_validation_tests_au_ps_composition_mandatory_sections_nilknown_warning
   end
 end

--- a/lib/au_ps_inferno/suite/generate_au_ps_using_ips_summary_validation_tests/au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning.rb
+++ b/lib/au_ps_inferno/suite/generate_au_ps_using_ips_summary_validation_tests/au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../../../utils/basic_test_class'
+
+module AUPSTestKit
+  # Warns against using emptyReason=nilknown instead of an explicit negation entry
+  class AUPSSuiteGenerateAuPsUsingIpsSummaryValidationTestsAuPsCompositionMandatorySectionsNilknownWarning < BasicTest
+    title 'AU PS Composition Mandatory Sections do not rely on emptyReason=nilknown'
+    description 'Warns when a mandatory section (Problems, Allergies, Medications) uses ' \
+                 'Composition.section.emptyReason = nilknown instead of an explicit negation code on the ' \
+                 "section's entry resource (e.g. AllergyIntolerance.code = 716186003 |No known allergy|). " \
+                 'AU PS prefers the explicit-entry pattern used by FHIR, IPS and AU Core over emptyReason ' \
+                 '- this is a warning, not a failure.'
+    id :suite_generate_au_ps_using_ips_summary_validation_tests_au_ps_composition_mandatory_sections_nilknown_warning
+
+    run do
+      warn_on_nilknown_empty_reason(%w[11450-4 48765-2 10160-0])
+    end
+  end
+end

--- a/lib/au_ps_inferno/suite/generate_au_ps_using_ips_summary_validation_tests/au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning.rb
+++ b/lib/au_ps_inferno/suite/generate_au_ps_using_ips_summary_validation_tests/au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning.rb
@@ -14,7 +14,7 @@ module AUPSTestKit
     id :suite_generate_au_ps_using_ips_summary_validation_tests_au_ps_composition_mandatory_sections_nilknown_warning
 
     run do
-      warn_on_nilknown_empty_reason(%w[11450-4 48765-2 10160-0])
+      warn_on_nilknown_empty_reason(MANDATORY_SECTIONS_CODES)
     end
   end
 end

--- a/lib/au_ps_inferno/suite/retrieve_au_ps_bundle_validation_tests/au_ps_composition_mandatory_sections.rb
+++ b/lib/au_ps_inferno/suite/retrieve_au_ps_bundle_validation_tests/au_ps_composition_mandatory_sections.rb
@@ -4,6 +4,8 @@ require_relative 'au_ps_composition_mandatory_sections/composition_mandatory_sec
 
 require_relative 'au_ps_composition_mandatory_sections/composition_mandatory_sections_mandatory_sections_entry_profiles'
 
+require_relative 'au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning'
+
 module AUPSTestKit
   # Automatically generated primitive group for AU PS Composition Mandatory Sections
   class AUPSSuiteRetrieveAuPsBundleValidationTestsAuPsCompositionMandatorySections < Inferno::TestGroup
@@ -16,5 +18,7 @@ module AUPSTestKit
     test from: :suite_retrieve_au_ps_bundle_validation_tests_au_ps_composition_mandatory_sections_sections_shall_populated
 
     test from: :suite_retrieve_au_ps_bundle_validation_tests_au_ps_composition_mandatory_sections_mandatory_sections_entry_profiles
+
+    test from: :suite_retrieve_au_ps_bundle_validation_tests_au_ps_composition_mandatory_sections_nilknown_warning
   end
 end

--- a/lib/au_ps_inferno/suite/retrieve_au_ps_bundle_validation_tests/au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning.rb
+++ b/lib/au_ps_inferno/suite/retrieve_au_ps_bundle_validation_tests/au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning.rb
@@ -14,7 +14,7 @@ module AUPSTestKit
     id :suite_retrieve_au_ps_bundle_validation_tests_au_ps_composition_mandatory_sections_nilknown_warning
 
     run do
-      warn_on_nilknown_empty_reason(%w[11450-4 48765-2 10160-0])
+      warn_on_nilknown_empty_reason(MANDATORY_SECTIONS_CODES)
     end
   end
 end

--- a/lib/au_ps_inferno/suite/retrieve_au_ps_bundle_validation_tests/au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning.rb
+++ b/lib/au_ps_inferno/suite/retrieve_au_ps_bundle_validation_tests/au_ps_composition_mandatory_sections/composition_mandatory_sections_nilknown_warning.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../../../utils/basic_test_class'
+
+module AUPSTestKit
+  # Warns against using emptyReason=nilknown instead of an explicit negation entry
+  class AUPSSuiteRetrieveAuPsBundleValidationTestsAuPsCompositionMandatorySectionsNilknownWarning < BasicTest
+    title 'AU PS Composition Mandatory Sections do not rely on emptyReason=nilknown'
+    description 'Warns when a mandatory section (Problems, Allergies, Medications) uses ' \
+                 'Composition.section.emptyReason = nilknown instead of an explicit negation code on the ' \
+                 "section's entry resource (e.g. AllergyIntolerance.code = 716186003 |No known allergy|). " \
+                 'AU PS prefers the explicit-entry pattern used by FHIR, IPS and AU Core over emptyReason ' \
+                 '- this is a warning, not a failure.'
+    id :suite_retrieve_au_ps_bundle_validation_tests_au_ps_composition_mandatory_sections_nilknown_warning
+
+    run do
+      warn_on_nilknown_empty_reason(%w[11450-4 48765-2 10160-0])
+    end
+  end
+end

--- a/lib/au_ps_inferno/utils/basic_test/composition_section_negation_module.rb
+++ b/lib/au_ps_inferno/utils/basic_test/composition_section_negation_module.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module AUPSTestKit
+  # Warns when a section uses emptyReason=nilknown instead of an explicit negation entry.
+  module BasicTestCompositionSectionNegationModule
+    NILKNOWN_SYSTEM = 'http://terminology.hl7.org/CodeSystem/list-empty-reason'
+    NILKNOWN_CODE = 'nilknown'
+
+    NEGATION_EXAMPLE_BY_SECTION = {
+      '11450-4' => 'Condition.code = 160245001 |No current problems or disability|',
+      '48765-2' => 'AllergyIntolerance.code = 716186003 |No known allergy|',
+      '10160-0' => 'MedicationStatement.medicationCodeableConcept = 787481004 |No known medications|'
+    }.freeze
+
+    private
+
+    def warn_on_nilknown_empty_reason(section_codes_array)
+      omit_unless_bundle_in_scratch
+
+      composition = BundleDecorator.new(scratch_bundle).composition_resource
+      section_codes_array.each { |code| warn_if_section_nilknown(composition, code) }
+
+      assert true
+    end
+
+    def warn_if_section_nilknown(composition, section_code)
+      section = composition.section_by_code(section_code)
+      return if section.blank? || !nilknown_empty_reason?(section)
+
+      add_message('warning', nilknown_warning_text(section_code))
+    end
+
+    def nilknown_empty_reason?(section)
+      section.emptyReason&.coding&.any? do |coding|
+        coding.system == NILKNOWN_SYSTEM && coding.code == NILKNOWN_CODE
+      end
+    end
+
+    def nilknown_warning_text(section_code)
+      example = NEGATION_EXAMPLE_BY_SECTION.fetch(section_code, 'an explicit negation code per profile guidance')
+      "#{get_section_name(section_code)} uses emptyReason = nilknown ('Nil Known'). " \
+        'AU PS prefers an explicit negation code on the section entry instead ' \
+        "of Composition.section.emptyReason, e.g. #{example}."
+    end
+  end
+end

--- a/lib/au_ps_inferno/utils/basic_test_class.rb
+++ b/lib/au_ps_inferno/utils/basic_test_class.rb
@@ -19,6 +19,7 @@ require_relative 'basic_test/composition_subelements_module'
 require_relative 'basic_test/ms_identifier_slices_module'
 require_relative 'basic_test/composition_elements_and_slices_module'
 require_relative 'basic_test/section_bundle_validation_module'
+require_relative 'basic_test/composition_section_negation_module'
 require_relative 'basic_test/resolve_path_debug_module'
 require_relative 'basic_test/ms_elements_populated_module'
 require_relative 'basic_test/ms_sub_elements_populated_module'
@@ -46,6 +47,7 @@ module AUPSTestKit
     include BasicTestMsIdentifierSlicesModule
     include BasicTestCompositionElementsAndSlicesModule
     include BasicTestSectionBundleValidationModule
+    include BasicTestCompositionSectionNegationModule
     include BasicTestResolvePathDebugModule
     include BasicTestMsElementsPopulatedModule
     include BasicTestMsSubElementsPopulatedModule

--- a/spec/fixtures/bundles/mandatory-negation-code-bundle.json
+++ b/spec/fixtures/bundles/mandatory-negation-code-bundle.json
@@ -1,0 +1,532 @@
+{
+  "resourceType": "Bundle",
+  "id": "aups-noknownx",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-bundle"
+    ]
+  },
+  "language": "en-AU",
+  "identifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:uuid:c1b07c4e-7a7a-4711-93e2-9a589b8c87e0"
+  },
+  "type": "document",
+  "timestamp": "2025-05-14T08:17:43.912+10:00",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:63b319ec-7321-4a70-973b-2cead2b28c28",
+      "resource": {
+        "resourceType": "Composition",
+        "id": "63b319ec-7321-4a70-973b-2cead2b28c28",
+        "meta": {
+          "profile": [
+            "http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-composition"
+          ]
+        },
+        "language": "en-AU",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\"><a name=\"Composition_63b319ec-7321-4a70-973b-2cead2b28c28\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Composition 63b319ec-7321-4a70-973b-2cead2b28c28</b></p><a name=\"63b319ec-7321-4a70-973b-2cead2b28c28\"> </a><a name=\"hc63b319ec-7321-4a70-973b-2cead2b28c28\"> </a><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Language: en-AU</p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-au-ps-composition.html\">AU PS Composition</a></p></div><p><b>status</b>: Final</p><p><b>type</b>: <span title=\"Codes:{http://loinc.org 60591-5}\">Patient summary Document</span></p><p><b>date</b>: 2025-05-14</p><p><b>author</b>: <a href=\"Bundle-aups-noknownx.html#urn-uuid-719de42c-3b25-45d6-b24f-ebec9a753175\">PractitionerRole Diagnostic and Interventional Radiologist</a></p><p><b>title</b>: Australian Patient Summary</p><p><b>custodian</b>: <a href=\"Bundle-aups-noknownx.html#urn-uuid-abfb35a4-7b89-46d1-be21-dec293999a1b\">Organization Douglas Radiology</a></p></div>"
+        },
+        "status": "final",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "60591-5",
+              "display": "Patient summary Document"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:03b8cc8a-df59-4daf-b9f2-8b49d3c7579a"
+        },
+        "date": "2025-05-14",
+        "author": [
+          {
+            "reference": "urn:uuid:719de42c-3b25-45d6-b24f-ebec9a753175"
+          }
+        ],
+        "title": "Australian Patient Summary",
+        "custodian": {
+          "reference": "urn:uuid:abfb35a4-7b89-46d1-be21-dec293999a1b"
+        },
+        "section": [
+          {
+            "title": "Active Problems",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "11450-4",
+                  "display": "Problem list - Reported"
+                }
+              ]
+            },
+            "text": {
+              "status": "generated",
+              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\">30/03/2025 No current problem or disability</div>"
+            },
+            "entry": [
+              {
+                "reference": "urn:uuid:df366c47-c739-4c16-939e-b5cf9afb0b7d"
+              }
+            ]
+          },
+          {
+            "title": "Active Allergies or Intolerances",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "48765-2",
+                  "display": "Allergies and adverse reactions Document"
+                }
+              ]
+            },
+            "text": {
+              "status": "generated",
+              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\">10/12/2024 No known allergy</div>"
+            },
+            "entry": [
+              {
+                "reference": "urn:uuid:9840a67e-3621-470d-9a7c-e559422591f5"
+              }
+            ]
+          },
+          {
+            "title": "Current Medicines",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "10160-0",
+                  "display": "History of Medication use Narrative"
+                }
+              ]
+            },
+            "text": {
+              "status": "generated",
+              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\">14/05/2025 No known current medicines</div>"
+            },
+            "entry": [
+              {
+                "reference": "urn:uuid:0fc878c1-a158-425f-ba08-ea4366fbb4e1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:03b8cc8a-df59-4daf-b9f2-8b49d3c7579a",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "03b8cc8a-df59-4daf-b9f2-8b49d3c7579a",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Patient_03b8cc8a-df59-4daf-b9f2-8b49d3c7579a\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Patient 03b8cc8a-df59-4daf-b9f2-8b49d3c7579a</b></p><a name=\"03b8cc8a-df59-4daf-b9f2-8b49d3c7579a\"> </a><a name=\"hc03b8cc8a-df59-4daf-b9f2-8b49d3c7579a\"> </a><p style=\"border: 1px #661aff solid; background-color: #e6e6ff; padding: 10px;\">Charlotte MORRIS  Female, DoB: 1994-11-11 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608500314687)</p><hr/><table class=\"grid\"><tr><td style=\"background-color: #f3f5da\" title=\"Ways to contact the Patient\">Contact Detail</td><td colspan=\"3\"><ul><li>ph: 0370106762(Work)</li><li>ph: 0491577644(Mobile)</li><li><a href=\"mailto:charlotte.morris@my-own-personal-domain.com\">charlotte.morris@my-own-personal-domain.com</a></li><li>ph: 0370103886(Home)</li><li>175 Zeppelin Ave Mountain View VIC 3988 AU </li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"This extension applies to the Patient, Person, and RelatedPerson resources and is used to indicate whether a person identifies as being of Aboriginal or Torres Strait Islander origin.\"><a href=\"http://hl7.org.au/fhir/6.0.0/StructureDefinition-indigenous-status.html\">Australian Indigenous Status</a></td><td colspan=\"3\">australian-indigenous-status-1: 1 (Aboriginal but not Torres Strait Islander origin)</td></tr></table></div>"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org.au/fhir/StructureDefinition/indigenous-status",
+            "valueCoding": {
+              "system": "https://healthterminologies.gov.au/fhir/CodeSystem/australian-indigenous-status-1",
+              "code": "1",
+              "display": "Aboriginal but not Torres Strait Islander origin"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+                "valueCoding": {
+                  "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+                  "code": "active"
+                }
+              },
+              {
+                "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+                "valueCoding": {
+                  "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+                  "code": "verified",
+                  "display": "verified"
+                }
+              }
+            ],
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "NI"
+                }
+              ],
+              "text": "IHI"
+            },
+            "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+            "value": "8003608500314687"
+          }
+        ],
+        "name": [
+          {
+            "use": "usual",
+            "family": "MORRIS",
+            "given": [
+              "Charlotte"
+            ]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "0370106762",
+            "use": "work"
+          },
+          {
+            "system": "phone",
+            "value": "0491577644",
+            "use": "mobile"
+          },
+          {
+            "system": "email",
+            "value": "charlotte.morris@my-own-personal-domain.com"
+          },
+          {
+            "system": "phone",
+            "value": "0370103886",
+            "use": "home"
+          }
+        ],
+        "gender": "female",
+        "birthDate": "1994-11-11",
+        "address": [
+          {
+            "line": [
+              "175 Zeppelin Ave"
+            ],
+            "city": "Mountain View",
+            "state": "VIC",
+            "postalCode": "3988",
+            "country": "AU"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:abfb35a4-7b89-46d1-be21-dec293999a1b",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "abfb35a4-7b89-46d1-be21-dec293999a1b",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Organization_abfb35a4-7b89-46d1-be21-dec293999a1b\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Organization abfb35a4-7b89-46d1-be21-dec293999a1b</b></p><a name=\"abfb35a4-7b89-46d1-be21-dec293999a1b\"> </a><a name=\"hcabfb35a4-7b89-46d1-be21-dec293999a1b\"> </a><p><b>identifier</b>: HPI-O/8003629900040482, ABN/81132303164</p><p><b>type</b>: <span title=\"Codes:{http://www.abs.gov.au/ausstats/abs@.nsf/mf/1292.0 8520}, {http://snomed.info/sct 708175003}\">Diagnostic Radiology</span></p><p><b>name</b>: Douglas Radiology</p><p><b>telecom</b>: ph: 0355500107(Work), <a href=\"mailto:reception@douglasradiology.example.com.au\">reception@douglasradiology.example.com.au</a></p><p><b>address</b>: 74 Freedom Lane Douglas VIC 3401 </p></div>"
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+                  "code": "NOI"
+                }
+              ],
+              "text": "HPI-O"
+            },
+            "system": "http://ns.electronichealth.net.au/id/hi/hpio/1.0",
+            "value": "8003629900040482"
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "XX"
+                }
+              ],
+              "text": "ABN"
+            },
+            "system": "http://hl7.org.au/id/abn",
+            "value": "81132303164"
+          }
+        ],
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://www.abs.gov.au/ausstats/abs@.nsf/mf/1292.0",
+                "code": "8520",
+                "display": "Pathology and Diagnostic Imaging Services"
+              },
+              {
+                "system": "http://snomed.info/sct",
+                "code": "708175003",
+                "display": "Diagnostic imaging service"
+              }
+            ],
+            "text": "Diagnostic Radiology"
+          }
+        ],
+        "name": "Douglas Radiology",
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "0355500107",
+            "use": "work"
+          },
+          {
+            "system": "email",
+            "value": "reception@douglasradiology.example.com.au"
+          }
+        ],
+        "address": [
+          {
+            "line": [
+              "74 Freedom Lane"
+            ],
+            "city": "Douglas",
+            "state": "VIC",
+            "postalCode": "3401"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:719de42c-3b25-45d6-b24f-ebec9a753175",
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "719de42c-3b25-45d6-b24f-ebec9a753175",
+        "meta": {
+          "profile": [
+            "http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-practitionerrole"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"PractitionerRole_719de42c-3b25-45d6-b24f-ebec9a753175\"> </a><p class=\"res-header-id\"><b>Generated Narrative: PractitionerRole 719de42c-3b25-45d6-b24f-ebec9a753175</b></p><a name=\"719de42c-3b25-45d6-b24f-ebec9a753175\"> </a><a name=\"hc719de42c-3b25-45d6-b24f-ebec9a753175\"> </a><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\"/><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-au-ps-practitionerrole.html\">AU PS PractitionerRole</a></p></div><p><b>identifier</b>: Medicare Provider Number/2449191X</p><p><b>practitioner</b>: <a href=\"Bundle-aups-noknownx.html#urn-uuid-f8135a88-5992-4a78-8d9f-6bc3f533292d\">Practitioner Palmer BURDETT </a></p><p><b>organization</b>: <a href=\"Bundle-aups-noknownx.html#urn-uuid-abfb35a4-7b89-46d1-be21-dec293999a1b\">Organization Douglas Radiology</a></p><p><b>code</b>: <span title=\"Codes:{http://www.abs.gov.au/ausstats/abs@.nsf/mf/1220.0 253917}\">Diagnostic and Interventional Radiologist</span></p><p><b>specialty</b>: <span title=\"Codes:{http://snomed.info/sct 408455009}\">Interventional radiology - speciality</span></p><p><b>telecom</b>: ph: 0370101180(Work), <a href=\"mailto:palmer.burdett@douglasradiology.example.com.au\">palmer.burdett@douglasradiology.example.com.au</a></p></div>"
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+                  "code": "UPIN"
+                }
+              ],
+              "text": "Medicare Provider Number"
+            },
+            "system": "http://ns.electronichealth.net.au/id/medicare-provider-number",
+            "value": "2449191X"
+          }
+        ],
+        "practitioner": {
+          "reference": "urn:uuid:f8135a88-5992-4a78-8d9f-6bc3f533292d"
+        },
+        "organization": {
+          "reference": "urn:uuid:abfb35a4-7b89-46d1-be21-dec293999a1b"
+        },
+        "code": [
+          {
+            "coding": [
+              {
+                "system": "http://www.abs.gov.au/ausstats/abs@.nsf/mf/1220.0",
+                "code": "253917"
+              }
+            ]
+          }
+        ],
+        "specialty": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "408455009"
+              }
+            ]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "0370101180",
+            "use": "work"
+          },
+          {
+            "system": "email",
+            "value": "palmer.burdett@douglasradiology.example.com.au",
+            "use": "work"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:f8135a88-5992-4a78-8d9f-6bc3f533292d",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "f8135a88-5992-4a78-8d9f-6bc3f533292d",
+        "meta": {
+          "profile": [
+            "http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-practitioner"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Practitioner_f8135a88-5992-4a78-8d9f-6bc3f533292d\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Practitioner f8135a88-5992-4a78-8d9f-6bc3f533292d</b></p><a name=\"f8135a88-5992-4a78-8d9f-6bc3f533292d\"> </a><a name=\"hcf8135a88-5992-4a78-8d9f-6bc3f533292d\"> </a><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\"/><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-au-ps-practitioner.html\">AU PS Practitioner</a></p></div><p><b>identifier</b>: HPI-I/8003616566719012</p><p><b>name</b>: Palmer BURDETT </p><p><b>telecom</b>: ph: 0370101180(Work), <a href=\"mailto:palmer.burdett@douglasradiology.example.com.au\">palmer.burdett@douglasradiology.example.com.au</a></p><p><b>address</b>: 31 Museum Pde Douglas VIC 3401 </p></div>"
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "NPI",
+                  "display": "National provider identifier"
+                }
+              ],
+              "text": "HPI-I"
+            },
+            "system": "http://ns.electronichealth.net.au/id/hi/hpii/1.0",
+            "value": "8003616566719012"
+          }
+        ],
+        "name": [
+          {
+            "family": "BURDETT",
+            "given": [
+              "Palmer"
+            ]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "0370101180",
+            "use": "work"
+          },
+          {
+            "system": "email",
+            "value": "palmer.burdett@douglasradiology.example.com.au"
+          }
+        ],
+        "address": [
+          {
+            "line": [
+              "31 Museum Pde"
+            ],
+            "city": "Douglas",
+            "state": "VIC",
+            "postalCode": "3401"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:9840a67e-3621-470d-9a7c-e559422591f5",
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "9840a67e-3621-470d-9a7c-e559422591f5",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"AllergyIntolerance_9840a67e-3621-470d-9a7c-e559422591f5\"> </a><p class=\"res-header-id\"><b>Generated Narrative: AllergyIntolerance 9840a67e-3621-470d-9a7c-e559422591f5</b></p><a name=\"9840a67e-3621-470d-9a7c-e559422591f5\"> </a><a name=\"hc9840a67e-3621-470d-9a7c-e559422591f5\"> </a><p><b>clinicalStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical active}\">Active</span></p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 716186003}\">No known allergy</span></p><p><b>patient</b>: <a href=\"Bundle-aups-noknownx.html#urn-uuid-03b8cc8a-df59-4daf-b9f2-8b49d3c7579a\">Charlotte MORRIS  Female, DoB: 1994-11-11 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608500314687)</a></p><p><b>recordedDate</b>: 2024-12-10</p></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "716186003",
+              "display": "No known allergy"
+            }
+          ],
+          "text": "No known allergy"
+        },
+        "patient": {
+          "reference": "urn:uuid:03b8cc8a-df59-4daf-b9f2-8b49d3c7579a"
+        },
+        "recordedDate": "2024-12-10"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:0fc878c1-a158-425f-ba08-ea4366fbb4e1",
+      "resource": {
+        "resourceType": "MedicationStatement",
+        "id": "0fc878c1-a158-425f-ba08-ea4366fbb4e1",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"MedicationStatement_0fc878c1-a158-425f-ba08-ea4366fbb4e1\"> </a><p class=\"res-header-id\"><b>Generated Narrative: MedicationStatement 0fc878c1-a158-425f-ba08-ea4366fbb4e1</b></p><a name=\"0fc878c1-a158-425f-ba08-ea4366fbb4e1\"> </a><a name=\"hc0fc878c1-a158-425f-ba08-ea4366fbb4e1\"> </a><p><b>status</b>: Active</p><p><b>medication</b>: <span title=\"Codes:{http://snomed.info/sct 787481004}\">No known current medicines</span></p><p><b>subject</b>: <a href=\"Bundle-aups-noknownx.html#urn-uuid-03b8cc8a-df59-4daf-b9f2-8b49d3c7579a\">Charlotte MORRIS  Female, DoB: 1994-11-11 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608500314687)</a></p><p><b>effective</b>: 2025-05-14</p></div>"
+        },
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "787481004",
+              "display": "No known medications"
+            }
+          ],
+          "text": "No known current medicines"
+        },
+        "subject": {
+          "reference": "urn:uuid:03b8cc8a-df59-4daf-b9f2-8b49d3c7579a"
+        },
+        "effectiveDateTime": "2025-05-14"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:df366c47-c739-4c16-939e-b5cf9afb0b7d",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "df366c47-c739-4c16-939e-b5cf9afb0b7d",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Condition_df366c47-c739-4c16-939e-b5cf9afb0b7d\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Condition df366c47-c739-4c16-939e-b5cf9afb0b7d</b></p><a name=\"df366c47-c739-4c16-939e-b5cf9afb0b7d\"> </a><a name=\"hcdf366c47-c739-4c16-939e-b5cf9afb0b7d\"> </a><p><b>clinicalStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/condition-clinical active}\">Active</span></p><p><b>category</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/condition-category problem-list-item}\">Problem List Item</span></p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 160245001}\">No current problems or disability</span></p><p><b>subject</b>: <a href=\"Bundle-aups-noknownx.html#urn-uuid-03b8cc8a-df59-4daf-b9f2-8b49d3c7579a\">Charlotte MORRIS  Female, DoB: 1994-11-11 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608500314687)</a></p><p><b>recordedDate</b>: 2025-03-30</p></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "problem-list-item",
+                "display": "Problem List Item"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "160245001",
+              "display": "No current problems or disability"
+            }
+          ],
+          "text": "No current problems or disability"
+        },
+        "subject": {
+          "reference": "urn:uuid:03b8cc8a-df59-4daf-b9f2-8b49d3c7579a"
+        },
+        "recordedDate": "2025-03-30"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/bundles/mandatory-nilknown-warning-bundle.json
+++ b/spec/fixtures/bundles/mandatory-nilknown-warning-bundle.json
@@ -1,0 +1,719 @@
+{
+  "resourceType": "Bundle",
+  "id": "aups-basicsummary",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-bundle"
+    ]
+  },
+  "language": "en-AU",
+  "identifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:uuid:0bd27fed-5f11-4344-beeb-c3b78c00f604"
+  },
+  "type": "document",
+  "timestamp": "2025-02-05T19:33:11.0607701+10:00",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:c5359ef2-ef27-445a-833a-c53e6bb437c5",
+      "resource": {
+        "resourceType": "Composition",
+        "id": "c5359ef2-ef27-445a-833a-c53e6bb437c5",
+        "meta": {
+          "versionId": "1"
+        },
+        "language": "en-AU",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\"><a name=\"Composition_c5359ef2-ef27-445a-833a-c53e6bb437c5\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Composition c5359ef2-ef27-445a-833a-c53e6bb437c5</b></p><a name=\"c5359ef2-ef27-445a-833a-c53e6bb437c5\"> </a><a name=\"hcc5359ef2-ef27-445a-833a-c53e6bb437c5\"> </a><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">version: 1; Language: en-AU</p></div><p><b>status</b>: Final</p><p><b>type</b>: <span title=\"Codes:{http://loinc.org 60591-5}\">Patient summary Document</span></p><p><b>date</b>: 2025-02-03</p><p><b>author</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-463c2982-3759-4022-b40e-521bbe54d544\">PractitionerRole General practitioner</a></p><p><b>title</b>: Australian Patient Summary</p><p><b>custodian</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-70a756e3-20b3-4637-8601-a222983e295a\">Organization Bobrester Medical Center</a></p></div>"
+        },
+        "status": "final",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "60591-5",
+              "display": "Patient summary Document"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+        },
+        "date": "2025-02-03",
+        "author": [
+          {
+            "reference": "urn:uuid:463c2982-3759-4022-b40e-521bbe54d544"
+          }
+        ],
+        "title": "Australian Patient Summary",
+        "custodian": {
+          "reference": "urn:uuid:70a756e3-20b3-4637-8601-a222983e295a"
+        },
+        "section": [
+          {
+            "title": "Active Problems",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "11450-4",
+                  "display": "Problem list - Reported"
+                }
+              ]
+            },
+            "text": {
+              "status": "generated",
+              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\">21/12/2024 No current problem or disability.</div>"
+            },
+            "entry": [
+              {
+                "reference": "urn:uuid:310f1593-d610-4144-a6e8-1f823d955e0d"
+              }
+            ]
+          },
+          {
+            "title": "Active Allergies or Intolerances",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "48765-2",
+                  "display": "Allergies and adverse reactions Document"
+                }
+              ]
+            },
+            "text": {
+              "status": "generated",
+              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\">\n            <table border=\"1\">\n              <thead>\n                <tr>\n                  <th>Allergy, Intolerance, Substance</th>\n                  <th>Onset</th>\n                  <th>Recorded</th>\n                  <th>Manifestation</th>\n                  <th>Manifestation Severity</th>\n                </tr>\n              </thead>\n              <tbody>\n                <tr>\n                  <td>Intolerance to lactose</td>\n                  <td>2022</td>\n                  <td>14/03/2023</td>\n                  <td>Abdominal pain, Abdominal bloating, Diarrhoea</td>\n                  <td>Mild</td>\n                </tr>\n                <tr>\n                  <td>Gluten intolerance</td>\n                  <td>1999</td>\n                  <td>12/01/2023</td>\n                  <td>Fatigue</td>\n                  <td>Mild</td>\n                </tr>\n                <tr>\n                  <td>Chlorhexidine</td>\n                  <td>12/01/2023</td>\n                  <td>09/09/2023</td>\n                  <td>Hives</td>\n                  <td>Mild</td>\n                </tr>\n              </tbody>\n            </table>\n            </div>"
+            },
+            "emptyReason": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/list-empty-reason",
+                  "code": "nilknown",
+                  "display": "Nil Known"
+                }
+              ]
+            }
+          },
+          {
+            "title": "Current Medicines",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "10160-0",
+                  "display": "History of Medication use Narrative"
+                }
+              ]
+            },
+            "text": {
+              "status": "generated",
+              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\">\n              <table border=\"1\">\n                <thead>\n                  <tr>\n                    <th>Medicine</th>\n                    <th>Directions</th>\n                    <th>Date asserted</th>\n                  </tr>\n                </thead>\n                <tbody>\n                  <tr>\n                    <td><b>Bisoprolol</b> 2.5mg tab</td>\n                    <td>Take 1/2 tablet in the morning</td>\n                    <td>05/01/2025</td>\n                  </tr>\n                </tbody>\n              </table>\n            </div>"
+            },
+            "entry": [
+              {
+                "reference": "urn:uuid:347e8435-cea1-4e94-9755-abb027926bb1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "9be88cc6-09e8-4dc6-b058-88676240dbc7",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Patient_9be88cc6-09e8-4dc6-b058-88676240dbc7\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Patient 9be88cc6-09e8-4dc6-b058-88676240dbc7</b></p><a name=\"9be88cc6-09e8-4dc6-b058-88676240dbc7\"> </a><a name=\"hc9be88cc6-09e8-4dc6-b058-88676240dbc7\"> </a><p style=\"border: 1px #661aff solid; background-color: #e6e6ff; padding: 10px;\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</p><hr/><table class=\"grid\"><tr><td style=\"background-color: #f3f5da\" title=\"Ways to contact the Patient\">Contact Detail</td><td colspan=\"3\"><ul><li>ph: 0270102724(Work)</li><li>ph: 0491574632(Mobile)</li><li>ph: 0270107520(Home)</li><li><a href=\"mailto:mia.banks@myownpersonaldomain.com\">mia.banks@myownpersonaldomain.com</a></li><li>ph: 270107520(Home)</li><li>50 Sebastien St Minjary NSW 2720 AU </li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"The pronouns to use when referring to an individual in verbal or written communication.\">Individual Pronouns:</td><td colspan=\"3\"><ul><li>value: <span title=\"Codes:{http://loinc.org LA29519-8}\">she/her/her/hers/herself</span></li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"An individual's personal sense of being a man, woman, boy, girl, nonbinary, or something else. This represents an individual\u2019s identity, ascertained by asking them what that identity is. \n In the case where the gender identity is communicated by a third party, for example, if a spouse indicates the gender identity of their partner on an intake form, a Provenance resource can be used with a Provenance.target referring to the Patient, with a targetElement extension identifying the gender identity extension as the target element within the Patient resource.  When exchanging this concept, refer to the guidance in the [Gender Harmony Implementation Guide](http://hl7.org/xprod/ig/uv/gender-harmony/).\">Individual Gender Identity:</td><td colspan=\"3\"><ul><li>value: <span title=\"Codes:{http://snomed.info/sct 446141000124107}\">Identifies as female gender</span></li></ul></td></tr></table></div>"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/individual-genderIdentity",
+            "extension": [
+              {
+                "url": "value",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://snomed.info/sct",
+                      "code": "446141000124107",
+                      "display": "Identifies as female gender"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/individual-pronouns",
+            "extension": [
+              {
+                "url": "value",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "LA29519-8",
+                      "display": "she/her/her/hers/herself"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+                "valueCoding": {
+                  "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+                  "code": "active"
+                }
+              },
+              {
+                "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+                "valueCoding": {
+                  "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+                  "code": "verified",
+                  "display": "verified"
+                }
+              }
+            ],
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "NI"
+                }
+              ],
+              "text": "IHI"
+            },
+            "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+            "value": "8003608333647261"
+          }
+        ],
+        "name": [
+          {
+            "use": "usual",
+            "family": "Banks",
+            "given": [
+              "Mia",
+              "Leanne"
+            ]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "0270102724",
+            "use": "work"
+          },
+          {
+            "system": "phone",
+            "value": "0491574632",
+            "use": "mobile"
+          },
+          {
+            "system": "phone",
+            "value": "0270107520",
+            "use": "home"
+          },
+          {
+            "system": "email",
+            "value": "mia.banks@myownpersonaldomain.com"
+          },
+          {
+            "system": "phone",
+            "value": "270107520",
+            "use": "home"
+          }
+        ],
+        "gender": "female",
+        "birthDate": "1983-08-25",
+        "address": [
+          {
+            "line": [
+              "50 Sebastien St"
+            ],
+            "city": "Minjary",
+            "state": "NSW",
+            "postalCode": "2720",
+            "country": "AU"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:70a756e3-20b3-4637-8601-a222983e295a",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "70a756e3-20b3-4637-8601-a222983e295a",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Organization_70a756e3-20b3-4637-8601-a222983e295a\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Organization 70a756e3-20b3-4637-8601-a222983e295a</b></p><a name=\"70a756e3-20b3-4637-8601-a222983e295a\"> </a><a name=\"hc70a756e3-20b3-4637-8601-a222983e295a\"> </a><p><b>identifier</b>: ABN/12345678901</p><p><b>type</b>: <span title=\"Codes:{http://snomed.info/sct 288565001}\">Medical Center</span></p><p><b>name</b>: Bobrester Medical Center</p><p><b>telecom</b>: <a href=\"mailto:info@bobrestermedical.example.com\">info@bobrestermedical.example.com</a>, ph: (07) 5550 2427(Work)</p><p><b>address</b>: 87 Western Esp Tindal RAAF QLD 4655 AU </p></div>"
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "XX"
+                }
+              ],
+              "text": "ABN"
+            },
+            "system": "http://hl7.org.au/id/abn",
+            "value": "12345678901"
+          }
+        ],
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "288565001",
+                "display": "Medical centre"
+              }
+            ],
+            "text": "Medical Center"
+          }
+        ],
+        "name": "Bobrester Medical Center",
+        "telecom": [
+          {
+            "system": "email",
+            "value": "info@bobrestermedical.example.com",
+            "use": "work"
+          },
+          {
+            "system": "phone",
+            "value": "(07) 5550 2427",
+            "use": "work"
+          }
+        ],
+        "address": [
+          {
+            "line": [
+              "87 Western Esp"
+            ],
+            "city": "Tindal RAAF",
+            "state": "QLD",
+            "postalCode": "4655",
+            "country": "AU"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:463c2982-3759-4022-b40e-521bbe54d544",
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "463c2982-3759-4022-b40e-521bbe54d544",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"PractitionerRole_463c2982-3759-4022-b40e-521bbe54d544\"> </a><p class=\"res-header-id\"><b>Generated Narrative: PractitionerRole 463c2982-3759-4022-b40e-521bbe54d544</b></p><a name=\"463c2982-3759-4022-b40e-521bbe54d544\"> </a><a name=\"hc463c2982-3759-4022-b40e-521bbe54d544\"> </a><p><b>identifier</b>: Employee Number/12345678</p><p><b>practitioner</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-dce50472-2a94-47e6-9501-b52f0df0c813\">Practitioner Bob Bobrester </a></p><p><b>organization</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-70a756e3-20b3-4637-8601-a222983e295a\">Organization Bobrester Medical Center</a></p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 62247001}, {http://www.abs.gov.au/ausstats/abs@.nsf/mf/1220.0 253111}\">General Practitioner</span></p><p><b>telecom</b>: ph: 0491579760, <a href=\"mailto:drbob@bobrestermedical.example.com\">drbob@bobrestermedical.example.com</a></p></div>"
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "EI",
+                  "display": "Employee number"
+                }
+              ],
+              "text": "Employee Number"
+            },
+            "system": "http://ns.electronichealth.net.au/id/abn-scoped/service-provider-individual/1.0/12345678901",
+            "value": "12345678",
+            "assigner": {
+              "display": "Bobrester Medical Center"
+            }
+          }
+        ],
+        "practitioner": {
+          "reference": "urn:uuid:dce50472-2a94-47e6-9501-b52f0df0c813"
+        },
+        "organization": {
+          "reference": "urn:uuid:70a756e3-20b3-4637-8601-a222983e295a"
+        },
+        "code": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "62247001"
+              },
+              {
+                "system": "http://www.abs.gov.au/ausstats/abs@.nsf/mf/1220.0",
+                "code": "253111"
+              }
+            ],
+            "text": "General Practitioner"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "0491579760"
+          },
+          {
+            "system": "email",
+            "value": "drbob@bobrestermedical.example.com"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:dce50472-2a94-47e6-9501-b52f0df0c813",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "dce50472-2a94-47e6-9501-b52f0df0c813",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Practitioner_dce50472-2a94-47e6-9501-b52f0df0c813\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Practitioner dce50472-2a94-47e6-9501-b52f0df0c813</b></p><a name=\"dce50472-2a94-47e6-9501-b52f0df0c813\"> </a><a name=\"hcdce50472-2a94-47e6-9501-b52f0df0c813\"> </a><p><b>name</b>: Bob Bobrester </p></div>"
+        },
+        "name": [
+          {
+            "family": "Bobrester",
+            "given": [
+              "Bob"
+            ],
+            "prefix": [
+              "Dr."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:ad6fb7b7-c76f-441e-88a5-9051e795db26",
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "ad6fb7b7-c76f-441e-88a5-9051e795db26",
+        "note": [
+          {
+            "text": "This is a note about the allergy intolerance"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"AllergyIntolerance_ad6fb7b7-c76f-441e-88a5-9051e795db26\"> </a><p class=\"res-header-id\"><b>Generated Narrative: AllergyIntolerance ad6fb7b7-c76f-441e-88a5-9051e795db26</b></p><a name=\"ad6fb7b7-c76f-441e-88a5-9051e795db26\"> </a><a name=\"hcad6fb7b7-c76f-441e-88a5-9051e795db26\"> </a><p><b>clinicalStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical active}\">Active</span></p><p><b>verificationStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/allergyintolerance-verification confirmed}\">Confirmed</span></p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 782415009}\">Intolerance to lactose</span></p><p><b>patient</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>onset</b>: 2022</p><p><b>recordedDate</b>: 2023-03-14</p><blockquote><p><b>reaction</b></p><p><b>manifestation</b>: <span title=\"Codes:{http://snomed.info/sct 21522001}\">Abdominal pain</span>, <span title=\"Codes:{http://snomed.info/sct 116289008}\">Abdominal bloating</span>, <span title=\"Codes:{http://snomed.info/sct 62315008}\">Diarrhoea</span></p><p><b>severity</b>: Mild</p></blockquote></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "782415009",
+              "display": "Intolerance to lactose"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+        },
+        "onsetDateTime": "2022",
+        "recordedDate": "2023-03-14",
+        "reaction": [
+          {
+            "manifestation": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "21522001",
+                    "display": "Abdominal pain"
+                  }
+                ]
+              },
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "116289008",
+                    "display": "Abdominal bloating"
+                  }
+                ]
+              },
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "62315008",
+                    "display": "Diarrhoea"
+                  }
+                ]
+              }
+            ],
+            "severity": "mild"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:06ba95f5-345b-412d-aa66-99e354470015",
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "06ba95f5-345b-412d-aa66-99e354470015",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"AllergyIntolerance_06ba95f5-345b-412d-aa66-99e354470015\"> </a><p class=\"res-header-id\"><b>Generated Narrative: AllergyIntolerance 06ba95f5-345b-412d-aa66-99e354470015</b></p><a name=\"06ba95f5-345b-412d-aa66-99e354470015\"> </a><a name=\"hc06ba95f5-345b-412d-aa66-99e354470015\"> </a><p><b>clinicalStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical active}\">Active</span></p><p><b>type</b>: Intolerance</p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 1269424006}\">Gluten intolerance</span></p><p><b>patient</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>onset</b>: 1999</p><p><b>recordedDate</b>: 2023-01-12</p><h3>Reactions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Substance</b></td><td><b>Manifestation</b></td><td><b>Severity</b></td></tr><tr><td style=\"display: none\">*</td><td><span title=\"Codes:{http://snomed.info/sct 89811004}\">Gluten</span></td><td><span title=\"Codes:{http://snomed.info/sct 84229001}\">Fatigue</span></td><td>Mild</td></tr></table></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ],
+          "text": "Active"
+        },
+        "type": "intolerance",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "1269424006"
+            }
+          ],
+          "text": "Gluten intolerance"
+        },
+        "patient": {
+          "reference": "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+        },
+        "onsetDateTime": "1999",
+        "recordedDate": "2023-01-12",
+        "reaction": [
+          {
+            "substance": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "89811004"
+                }
+              ],
+              "text": "Gluten"
+            },
+            "manifestation": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "84229001"
+                  }
+                ],
+                "text": "Fatigue"
+              }
+            ],
+            "severity": "mild"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:d24db2d5-3400-4158-892c-d018acdeba09",
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "d24db2d5-3400-4158-892c-d018acdeba09",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"AllergyIntolerance_d24db2d5-3400-4158-892c-d018acdeba09\"> </a><p class=\"res-header-id\"><b>Generated Narrative: AllergyIntolerance d24db2d5-3400-4158-892c-d018acdeba09</b></p><a name=\"d24db2d5-3400-4158-892c-d018acdeba09\"> </a><a name=\"hcd24db2d5-3400-4158-892c-d018acdeba09\"> </a><p><b>clinicalStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical active}\">Active</span></p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 373568007}\">Chlorhexidine</span></p><p><b>patient</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>onset</b>: 2023-01-12</p><p><b>recordedDate</b>: 2023-09-09</p><h3>Reactions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Substance</b></td><td><b>Manifestation</b></td><td><b>Severity</b></td></tr><tr><td style=\"display: none\">*</td><td><span title=\"Codes:{http://snomed.info/sct 373568007}\">Chlorhexidine</span></td><td><span title=\"Codes:{http://snomed.info/sct 247472004}\">Hives</span></td><td>Mild</td></tr></table></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ],
+          "text": "Active"
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "373568007"
+            }
+          ],
+          "text": "Chlorhexidine"
+        },
+        "patient": {
+          "reference": "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+        },
+        "onsetDateTime": "2023-01-12",
+        "recordedDate": "2023-09-09",
+        "reaction": [
+          {
+            "substance": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "373568007"
+                }
+              ],
+              "text": "Chlorhexidine"
+            },
+            "manifestation": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "247472004"
+                  }
+                ],
+                "text": "Hives"
+              }
+            ],
+            "severity": "mild"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:347e8435-cea1-4e94-9755-abb027926bb1",
+      "resource": {
+        "resourceType": "MedicationStatement",
+        "id": "347e8435-cea1-4e94-9755-abb027926bb1",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"MedicationStatement_347e8435-cea1-4e94-9755-abb027926bb1\"> </a><p class=\"res-header-id\"><b>Generated Narrative: MedicationStatement 347e8435-cea1-4e94-9755-abb027926bb1</b></p><a name=\"347e8435-cea1-4e94-9755-abb027926bb1\"> </a><a name=\"hc347e8435-cea1-4e94-9755-abb027926bb1\"> </a><p><b>status</b>: Active</p><p><b>medication</b>: <a href=\"#hc347e8435-cea1-4e94-9755-abb027926bb1/bisoprolol\">Medication Bisoprolol fumarate 2.5 mg tablet</a></p><p><b>subject</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>effective</b>: 2025-01-05</p><p><b>dateAsserted</b>: 2025-01-05</p><h3>Dosages</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Text</b></td></tr><tr><td style=\"display: none\">*</td><td>1/2 tablet in the morning</td></tr></table><hr/><blockquote><p class=\"res-header-id\"><b>Generated Narrative: Medication #bisoprolol</b></p><a name=\"347e8435-cea1-4e94-9755-abb027926bb1/bisoprolol\"> </a><a name=\"hc347e8435-cea1-4e94-9755-abb027926bb1/bisoprolol\"> </a><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 23281011000036106}\">Bisoprolol 2.5mg tab</span></p><p><b>form</b>: <span title=\"Codes:{http://snomed.info/sct 385055001}\">Tablet</span></p><h3>Ingredients</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Item[x]</b></td><td><b>Strength</b></td></tr><tr><td style=\"display: none\">*</td><td><span title=\"Codes:{http://snomed.info/sct 386869006}\">Bisoprolol fumarate</span></td><td>2.5 mg<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM  codemg = 'mg')</span>/1 Tablet<span style=\"background: LightGoldenRodYellow\"> (Details: SNOMED CT  code385055001 = 'Tablet')</span></td></tr></table></blockquote></div>"
+        },
+        "contained": [
+          {
+            "resourceType": "Medication",
+            "id": "bisoprolol",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "23281011000036106",
+                  "display": "Bisoprolol fumarate 2.5 mg tablet"
+                }
+              ],
+              "text": "Bisoprolol 2.5mg tab"
+            },
+            "form": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "385055001",
+                  "display": "Tablet"
+                }
+              ]
+            },
+            "ingredient": [
+              {
+                "itemCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://snomed.info/sct",
+                      "code": "386869006",
+                      "display": "Bisoprolol fumarate"
+                    }
+                  ]
+                },
+                "strength": {
+                  "numerator": {
+                    "value": 2.5,
+                    "system": "http://unitsofmeasure.org",
+                    "code": "mg"
+                  },
+                  "denominator": {
+                    "value": 1,
+                    "unit": "Tablet",
+                    "system": "http://snomed.info/sct",
+                    "code": "385055001"
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "status": "active",
+        "medicationReference": {
+          "reference": "#bisoprolol"
+        },
+        "subject": {
+          "reference": "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+        },
+        "effectiveDateTime": "2025-01-05",
+        "dateAsserted": "2025-01-05",
+        "dosage": [
+          {
+            "text": "1/2 tablet in the morning"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:310f1593-d610-4144-a6e8-1f823d955e0d",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "310f1593-d610-4144-a6e8-1f823d955e0d",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Condition_310f1593-d610-4144-a6e8-1f823d955e0d\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Condition 310f1593-d610-4144-a6e8-1f823d955e0d</b></p><a name=\"310f1593-d610-4144-a6e8-1f823d955e0d\"> </a><a name=\"hc310f1593-d610-4144-a6e8-1f823d955e0d\"> </a><p><b>clinicalStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/condition-clinical active}\">Active</span></p><p><b>category</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/condition-category problem-list-item}\">Problem List Item</span></p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 160245001}\">No current problems or disability</span></p><p><b>subject</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>recordedDate</b>: 2024-12-21</p></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "problem-list-item",
+                "display": "Problem List Item"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "160245001",
+              "display": "No current problems or disability"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+        },
+        "recordedDate": "2024-12-21"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/bundles/mandatory-unavailable-empty-reason-bundle.json
+++ b/spec/fixtures/bundles/mandatory-unavailable-empty-reason-bundle.json
@@ -1,0 +1,719 @@
+{
+  "resourceType": "Bundle",
+  "id": "aups-basicsummary",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-bundle"
+    ]
+  },
+  "language": "en-AU",
+  "identifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:uuid:0bd27fed-5f11-4344-beeb-c3b78c00f604"
+  },
+  "type": "document",
+  "timestamp": "2025-02-05T19:33:11.0607701+10:00",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:c5359ef2-ef27-445a-833a-c53e6bb437c5",
+      "resource": {
+        "resourceType": "Composition",
+        "id": "c5359ef2-ef27-445a-833a-c53e6bb437c5",
+        "meta": {
+          "versionId": "1"
+        },
+        "language": "en-AU",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\"><a name=\"Composition_c5359ef2-ef27-445a-833a-c53e6bb437c5\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Composition c5359ef2-ef27-445a-833a-c53e6bb437c5</b></p><a name=\"c5359ef2-ef27-445a-833a-c53e6bb437c5\"> </a><a name=\"hcc5359ef2-ef27-445a-833a-c53e6bb437c5\"> </a><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">version: 1; Language: en-AU</p></div><p><b>status</b>: Final</p><p><b>type</b>: <span title=\"Codes:{http://loinc.org 60591-5}\">Patient summary Document</span></p><p><b>date</b>: 2025-02-03</p><p><b>author</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-463c2982-3759-4022-b40e-521bbe54d544\">PractitionerRole General practitioner</a></p><p><b>title</b>: Australian Patient Summary</p><p><b>custodian</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-70a756e3-20b3-4637-8601-a222983e295a\">Organization Bobrester Medical Center</a></p></div>"
+        },
+        "status": "final",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "60591-5",
+              "display": "Patient summary Document"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+        },
+        "date": "2025-02-03",
+        "author": [
+          {
+            "reference": "urn:uuid:463c2982-3759-4022-b40e-521bbe54d544"
+          }
+        ],
+        "title": "Australian Patient Summary",
+        "custodian": {
+          "reference": "urn:uuid:70a756e3-20b3-4637-8601-a222983e295a"
+        },
+        "section": [
+          {
+            "title": "Active Problems",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "11450-4",
+                  "display": "Problem list - Reported"
+                }
+              ]
+            },
+            "text": {
+              "status": "generated",
+              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\">21/12/2024 No current problem or disability.</div>"
+            },
+            "entry": [
+              {
+                "reference": "urn:uuid:310f1593-d610-4144-a6e8-1f823d955e0d"
+              }
+            ]
+          },
+          {
+            "title": "Active Allergies or Intolerances",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "48765-2",
+                  "display": "Allergies and adverse reactions Document"
+                }
+              ]
+            },
+            "text": {
+              "status": "generated",
+              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\">\n            <table border=\"1\">\n              <thead>\n                <tr>\n                  <th>Allergy, Intolerance, Substance</th>\n                  <th>Onset</th>\n                  <th>Recorded</th>\n                  <th>Manifestation</th>\n                  <th>Manifestation Severity</th>\n                </tr>\n              </thead>\n              <tbody>\n                <tr>\n                  <td>Intolerance to lactose</td>\n                  <td>2022</td>\n                  <td>14/03/2023</td>\n                  <td>Abdominal pain, Abdominal bloating, Diarrhoea</td>\n                  <td>Mild</td>\n                </tr>\n                <tr>\n                  <td>Gluten intolerance</td>\n                  <td>1999</td>\n                  <td>12/01/2023</td>\n                  <td>Fatigue</td>\n                  <td>Mild</td>\n                </tr>\n                <tr>\n                  <td>Chlorhexidine</td>\n                  <td>12/01/2023</td>\n                  <td>09/09/2023</td>\n                  <td>Hives</td>\n                  <td>Mild</td>\n                </tr>\n              </tbody>\n            </table>\n            </div>"
+            },
+            "emptyReason": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/list-empty-reason",
+                  "code": "unavailable",
+                  "display": "Unavailable"
+                }
+              ]
+            }
+          },
+          {
+            "title": "Current Medicines",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "10160-0",
+                  "display": "History of Medication use Narrative"
+                }
+              ]
+            },
+            "text": {
+              "status": "generated",
+              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\">\n              <table border=\"1\">\n                <thead>\n                  <tr>\n                    <th>Medicine</th>\n                    <th>Directions</th>\n                    <th>Date asserted</th>\n                  </tr>\n                </thead>\n                <tbody>\n                  <tr>\n                    <td><b>Bisoprolol</b> 2.5mg tab</td>\n                    <td>Take 1/2 tablet in the morning</td>\n                    <td>05/01/2025</td>\n                  </tr>\n                </tbody>\n              </table>\n            </div>"
+            },
+            "entry": [
+              {
+                "reference": "urn:uuid:347e8435-cea1-4e94-9755-abb027926bb1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "9be88cc6-09e8-4dc6-b058-88676240dbc7",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Patient_9be88cc6-09e8-4dc6-b058-88676240dbc7\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Patient 9be88cc6-09e8-4dc6-b058-88676240dbc7</b></p><a name=\"9be88cc6-09e8-4dc6-b058-88676240dbc7\"> </a><a name=\"hc9be88cc6-09e8-4dc6-b058-88676240dbc7\"> </a><p style=\"border: 1px #661aff solid; background-color: #e6e6ff; padding: 10px;\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</p><hr/><table class=\"grid\"><tr><td style=\"background-color: #f3f5da\" title=\"Ways to contact the Patient\">Contact Detail</td><td colspan=\"3\"><ul><li>ph: 0270102724(Work)</li><li>ph: 0491574632(Mobile)</li><li>ph: 0270107520(Home)</li><li><a href=\"mailto:mia.banks@myownpersonaldomain.com\">mia.banks@myownpersonaldomain.com</a></li><li>ph: 270107520(Home)</li><li>50 Sebastien St Minjary NSW 2720 AU </li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"The pronouns to use when referring to an individual in verbal or written communication.\">Individual Pronouns:</td><td colspan=\"3\"><ul><li>value: <span title=\"Codes:{http://loinc.org LA29519-8}\">she/her/her/hers/herself</span></li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"An individual's personal sense of being a man, woman, boy, girl, nonbinary, or something else. This represents an individual\u2019s identity, ascertained by asking them what that identity is. \n In the case where the gender identity is communicated by a third party, for example, if a spouse indicates the gender identity of their partner on an intake form, a Provenance resource can be used with a Provenance.target referring to the Patient, with a targetElement extension identifying the gender identity extension as the target element within the Patient resource.  When exchanging this concept, refer to the guidance in the [Gender Harmony Implementation Guide](http://hl7.org/xprod/ig/uv/gender-harmony/).\">Individual Gender Identity:</td><td colspan=\"3\"><ul><li>value: <span title=\"Codes:{http://snomed.info/sct 446141000124107}\">Identifies as female gender</span></li></ul></td></tr></table></div>"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/individual-genderIdentity",
+            "extension": [
+              {
+                "url": "value",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://snomed.info/sct",
+                      "code": "446141000124107",
+                      "display": "Identifies as female gender"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/individual-pronouns",
+            "extension": [
+              {
+                "url": "value",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "LA29519-8",
+                      "display": "she/her/her/hers/herself"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+                "valueCoding": {
+                  "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+                  "code": "active"
+                }
+              },
+              {
+                "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+                "valueCoding": {
+                  "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+                  "code": "verified",
+                  "display": "verified"
+                }
+              }
+            ],
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "NI"
+                }
+              ],
+              "text": "IHI"
+            },
+            "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+            "value": "8003608333647261"
+          }
+        ],
+        "name": [
+          {
+            "use": "usual",
+            "family": "Banks",
+            "given": [
+              "Mia",
+              "Leanne"
+            ]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "0270102724",
+            "use": "work"
+          },
+          {
+            "system": "phone",
+            "value": "0491574632",
+            "use": "mobile"
+          },
+          {
+            "system": "phone",
+            "value": "0270107520",
+            "use": "home"
+          },
+          {
+            "system": "email",
+            "value": "mia.banks@myownpersonaldomain.com"
+          },
+          {
+            "system": "phone",
+            "value": "270107520",
+            "use": "home"
+          }
+        ],
+        "gender": "female",
+        "birthDate": "1983-08-25",
+        "address": [
+          {
+            "line": [
+              "50 Sebastien St"
+            ],
+            "city": "Minjary",
+            "state": "NSW",
+            "postalCode": "2720",
+            "country": "AU"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:70a756e3-20b3-4637-8601-a222983e295a",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "70a756e3-20b3-4637-8601-a222983e295a",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Organization_70a756e3-20b3-4637-8601-a222983e295a\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Organization 70a756e3-20b3-4637-8601-a222983e295a</b></p><a name=\"70a756e3-20b3-4637-8601-a222983e295a\"> </a><a name=\"hc70a756e3-20b3-4637-8601-a222983e295a\"> </a><p><b>identifier</b>: ABN/12345678901</p><p><b>type</b>: <span title=\"Codes:{http://snomed.info/sct 288565001}\">Medical Center</span></p><p><b>name</b>: Bobrester Medical Center</p><p><b>telecom</b>: <a href=\"mailto:info@bobrestermedical.example.com\">info@bobrestermedical.example.com</a>, ph: (07) 5550 2427(Work)</p><p><b>address</b>: 87 Western Esp Tindal RAAF QLD 4655 AU </p></div>"
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "XX"
+                }
+              ],
+              "text": "ABN"
+            },
+            "system": "http://hl7.org.au/id/abn",
+            "value": "12345678901"
+          }
+        ],
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "288565001",
+                "display": "Medical centre"
+              }
+            ],
+            "text": "Medical Center"
+          }
+        ],
+        "name": "Bobrester Medical Center",
+        "telecom": [
+          {
+            "system": "email",
+            "value": "info@bobrestermedical.example.com",
+            "use": "work"
+          },
+          {
+            "system": "phone",
+            "value": "(07) 5550 2427",
+            "use": "work"
+          }
+        ],
+        "address": [
+          {
+            "line": [
+              "87 Western Esp"
+            ],
+            "city": "Tindal RAAF",
+            "state": "QLD",
+            "postalCode": "4655",
+            "country": "AU"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:463c2982-3759-4022-b40e-521bbe54d544",
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "463c2982-3759-4022-b40e-521bbe54d544",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"PractitionerRole_463c2982-3759-4022-b40e-521bbe54d544\"> </a><p class=\"res-header-id\"><b>Generated Narrative: PractitionerRole 463c2982-3759-4022-b40e-521bbe54d544</b></p><a name=\"463c2982-3759-4022-b40e-521bbe54d544\"> </a><a name=\"hc463c2982-3759-4022-b40e-521bbe54d544\"> </a><p><b>identifier</b>: Employee Number/12345678</p><p><b>practitioner</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-dce50472-2a94-47e6-9501-b52f0df0c813\">Practitioner Bob Bobrester </a></p><p><b>organization</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-70a756e3-20b3-4637-8601-a222983e295a\">Organization Bobrester Medical Center</a></p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 62247001}, {http://www.abs.gov.au/ausstats/abs@.nsf/mf/1220.0 253111}\">General Practitioner</span></p><p><b>telecom</b>: ph: 0491579760, <a href=\"mailto:drbob@bobrestermedical.example.com\">drbob@bobrestermedical.example.com</a></p></div>"
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "EI",
+                  "display": "Employee number"
+                }
+              ],
+              "text": "Employee Number"
+            },
+            "system": "http://ns.electronichealth.net.au/id/abn-scoped/service-provider-individual/1.0/12345678901",
+            "value": "12345678",
+            "assigner": {
+              "display": "Bobrester Medical Center"
+            }
+          }
+        ],
+        "practitioner": {
+          "reference": "urn:uuid:dce50472-2a94-47e6-9501-b52f0df0c813"
+        },
+        "organization": {
+          "reference": "urn:uuid:70a756e3-20b3-4637-8601-a222983e295a"
+        },
+        "code": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "62247001"
+              },
+              {
+                "system": "http://www.abs.gov.au/ausstats/abs@.nsf/mf/1220.0",
+                "code": "253111"
+              }
+            ],
+            "text": "General Practitioner"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "0491579760"
+          },
+          {
+            "system": "email",
+            "value": "drbob@bobrestermedical.example.com"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:dce50472-2a94-47e6-9501-b52f0df0c813",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "dce50472-2a94-47e6-9501-b52f0df0c813",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Practitioner_dce50472-2a94-47e6-9501-b52f0df0c813\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Practitioner dce50472-2a94-47e6-9501-b52f0df0c813</b></p><a name=\"dce50472-2a94-47e6-9501-b52f0df0c813\"> </a><a name=\"hcdce50472-2a94-47e6-9501-b52f0df0c813\"> </a><p><b>name</b>: Bob Bobrester </p></div>"
+        },
+        "name": [
+          {
+            "family": "Bobrester",
+            "given": [
+              "Bob"
+            ],
+            "prefix": [
+              "Dr."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:ad6fb7b7-c76f-441e-88a5-9051e795db26",
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "ad6fb7b7-c76f-441e-88a5-9051e795db26",
+        "note": [
+          {
+            "text": "This is a note about the allergy intolerance"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"AllergyIntolerance_ad6fb7b7-c76f-441e-88a5-9051e795db26\"> </a><p class=\"res-header-id\"><b>Generated Narrative: AllergyIntolerance ad6fb7b7-c76f-441e-88a5-9051e795db26</b></p><a name=\"ad6fb7b7-c76f-441e-88a5-9051e795db26\"> </a><a name=\"hcad6fb7b7-c76f-441e-88a5-9051e795db26\"> </a><p><b>clinicalStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical active}\">Active</span></p><p><b>verificationStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/allergyintolerance-verification confirmed}\">Confirmed</span></p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 782415009}\">Intolerance to lactose</span></p><p><b>patient</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>onset</b>: 2022</p><p><b>recordedDate</b>: 2023-03-14</p><blockquote><p><b>reaction</b></p><p><b>manifestation</b>: <span title=\"Codes:{http://snomed.info/sct 21522001}\">Abdominal pain</span>, <span title=\"Codes:{http://snomed.info/sct 116289008}\">Abdominal bloating</span>, <span title=\"Codes:{http://snomed.info/sct 62315008}\">Diarrhoea</span></p><p><b>severity</b>: Mild</p></blockquote></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "782415009",
+              "display": "Intolerance to lactose"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+        },
+        "onsetDateTime": "2022",
+        "recordedDate": "2023-03-14",
+        "reaction": [
+          {
+            "manifestation": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "21522001",
+                    "display": "Abdominal pain"
+                  }
+                ]
+              },
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "116289008",
+                    "display": "Abdominal bloating"
+                  }
+                ]
+              },
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "62315008",
+                    "display": "Diarrhoea"
+                  }
+                ]
+              }
+            ],
+            "severity": "mild"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:06ba95f5-345b-412d-aa66-99e354470015",
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "06ba95f5-345b-412d-aa66-99e354470015",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"AllergyIntolerance_06ba95f5-345b-412d-aa66-99e354470015\"> </a><p class=\"res-header-id\"><b>Generated Narrative: AllergyIntolerance 06ba95f5-345b-412d-aa66-99e354470015</b></p><a name=\"06ba95f5-345b-412d-aa66-99e354470015\"> </a><a name=\"hc06ba95f5-345b-412d-aa66-99e354470015\"> </a><p><b>clinicalStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical active}\">Active</span></p><p><b>type</b>: Intolerance</p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 1269424006}\">Gluten intolerance</span></p><p><b>patient</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>onset</b>: 1999</p><p><b>recordedDate</b>: 2023-01-12</p><h3>Reactions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Substance</b></td><td><b>Manifestation</b></td><td><b>Severity</b></td></tr><tr><td style=\"display: none\">*</td><td><span title=\"Codes:{http://snomed.info/sct 89811004}\">Gluten</span></td><td><span title=\"Codes:{http://snomed.info/sct 84229001}\">Fatigue</span></td><td>Mild</td></tr></table></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ],
+          "text": "Active"
+        },
+        "type": "intolerance",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "1269424006"
+            }
+          ],
+          "text": "Gluten intolerance"
+        },
+        "patient": {
+          "reference": "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+        },
+        "onsetDateTime": "1999",
+        "recordedDate": "2023-01-12",
+        "reaction": [
+          {
+            "substance": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "89811004"
+                }
+              ],
+              "text": "Gluten"
+            },
+            "manifestation": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "84229001"
+                  }
+                ],
+                "text": "Fatigue"
+              }
+            ],
+            "severity": "mild"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:d24db2d5-3400-4158-892c-d018acdeba09",
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "d24db2d5-3400-4158-892c-d018acdeba09",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"AllergyIntolerance_d24db2d5-3400-4158-892c-d018acdeba09\"> </a><p class=\"res-header-id\"><b>Generated Narrative: AllergyIntolerance d24db2d5-3400-4158-892c-d018acdeba09</b></p><a name=\"d24db2d5-3400-4158-892c-d018acdeba09\"> </a><a name=\"hcd24db2d5-3400-4158-892c-d018acdeba09\"> </a><p><b>clinicalStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical active}\">Active</span></p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 373568007}\">Chlorhexidine</span></p><p><b>patient</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>onset</b>: 2023-01-12</p><p><b>recordedDate</b>: 2023-09-09</p><h3>Reactions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Substance</b></td><td><b>Manifestation</b></td><td><b>Severity</b></td></tr><tr><td style=\"display: none\">*</td><td><span title=\"Codes:{http://snomed.info/sct 373568007}\">Chlorhexidine</span></td><td><span title=\"Codes:{http://snomed.info/sct 247472004}\">Hives</span></td><td>Mild</td></tr></table></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ],
+          "text": "Active"
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "373568007"
+            }
+          ],
+          "text": "Chlorhexidine"
+        },
+        "patient": {
+          "reference": "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+        },
+        "onsetDateTime": "2023-01-12",
+        "recordedDate": "2023-09-09",
+        "reaction": [
+          {
+            "substance": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "373568007"
+                }
+              ],
+              "text": "Chlorhexidine"
+            },
+            "manifestation": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "247472004"
+                  }
+                ],
+                "text": "Hives"
+              }
+            ],
+            "severity": "mild"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:347e8435-cea1-4e94-9755-abb027926bb1",
+      "resource": {
+        "resourceType": "MedicationStatement",
+        "id": "347e8435-cea1-4e94-9755-abb027926bb1",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"MedicationStatement_347e8435-cea1-4e94-9755-abb027926bb1\"> </a><p class=\"res-header-id\"><b>Generated Narrative: MedicationStatement 347e8435-cea1-4e94-9755-abb027926bb1</b></p><a name=\"347e8435-cea1-4e94-9755-abb027926bb1\"> </a><a name=\"hc347e8435-cea1-4e94-9755-abb027926bb1\"> </a><p><b>status</b>: Active</p><p><b>medication</b>: <a href=\"#hc347e8435-cea1-4e94-9755-abb027926bb1/bisoprolol\">Medication Bisoprolol fumarate 2.5 mg tablet</a></p><p><b>subject</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>effective</b>: 2025-01-05</p><p><b>dateAsserted</b>: 2025-01-05</p><h3>Dosages</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Text</b></td></tr><tr><td style=\"display: none\">*</td><td>1/2 tablet in the morning</td></tr></table><hr/><blockquote><p class=\"res-header-id\"><b>Generated Narrative: Medication #bisoprolol</b></p><a name=\"347e8435-cea1-4e94-9755-abb027926bb1/bisoprolol\"> </a><a name=\"hc347e8435-cea1-4e94-9755-abb027926bb1/bisoprolol\"> </a><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 23281011000036106}\">Bisoprolol 2.5mg tab</span></p><p><b>form</b>: <span title=\"Codes:{http://snomed.info/sct 385055001}\">Tablet</span></p><h3>Ingredients</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Item[x]</b></td><td><b>Strength</b></td></tr><tr><td style=\"display: none\">*</td><td><span title=\"Codes:{http://snomed.info/sct 386869006}\">Bisoprolol fumarate</span></td><td>2.5 mg<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM  codemg = 'mg')</span>/1 Tablet<span style=\"background: LightGoldenRodYellow\"> (Details: SNOMED CT  code385055001 = 'Tablet')</span></td></tr></table></blockquote></div>"
+        },
+        "contained": [
+          {
+            "resourceType": "Medication",
+            "id": "bisoprolol",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "23281011000036106",
+                  "display": "Bisoprolol fumarate 2.5 mg tablet"
+                }
+              ],
+              "text": "Bisoprolol 2.5mg tab"
+            },
+            "form": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "385055001",
+                  "display": "Tablet"
+                }
+              ]
+            },
+            "ingredient": [
+              {
+                "itemCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://snomed.info/sct",
+                      "code": "386869006",
+                      "display": "Bisoprolol fumarate"
+                    }
+                  ]
+                },
+                "strength": {
+                  "numerator": {
+                    "value": 2.5,
+                    "system": "http://unitsofmeasure.org",
+                    "code": "mg"
+                  },
+                  "denominator": {
+                    "value": 1,
+                    "unit": "Tablet",
+                    "system": "http://snomed.info/sct",
+                    "code": "385055001"
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "status": "active",
+        "medicationReference": {
+          "reference": "#bisoprolol"
+        },
+        "subject": {
+          "reference": "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+        },
+        "effectiveDateTime": "2025-01-05",
+        "dateAsserted": "2025-01-05",
+        "dosage": [
+          {
+            "text": "1/2 tablet in the morning"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:310f1593-d610-4144-a6e8-1f823d955e0d",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "310f1593-d610-4144-a6e8-1f823d955e0d",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Condition_310f1593-d610-4144-a6e8-1f823d955e0d\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Condition 310f1593-d610-4144-a6e8-1f823d955e0d</b></p><a name=\"310f1593-d610-4144-a6e8-1f823d955e0d\"> </a><a name=\"hc310f1593-d610-4144-a6e8-1f823d955e0d\"> </a><p><b>clinicalStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/condition-clinical active}\">Active</span></p><p><b>category</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/condition-category problem-list-item}\">Problem List Item</span></p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 160245001}\">No current problems or disability</span></p><p><b>subject</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>recordedDate</b>: 2024-12-21</p></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "problem-list-item",
+                "display": "Problem List Item"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "160245001",
+              "display": "No current problems or disability"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+        },
+        "recordedDate": "2024-12-21"
+      }
+    }
+  ]
+}

--- a/spec/support/basic_test/composition_section_negation_spec_setup.rb
+++ b/spec/support/basic_test/composition_section_negation_spec_setup.rb
@@ -17,7 +17,9 @@ RSpec.shared_context 'composition section negation check setup' do
 
       id test_id
 
-      run { warn_on_nilknown_empty_reason(AUPSTestKit::BasicTestCompositionSectionReadModule::MANDATORY_SECTIONS_CODES) }
+      run do
+        warn_on_nilknown_empty_reason(AUPSTestKit::BasicTestCompositionSectionReadModule::MANDATORY_SECTIONS_CODES)
+      end
     end
 
     repo = Inferno::Repositories::Tests.new

--- a/spec/support/basic_test/composition_section_negation_spec_setup.rb
+++ b/spec/support/basic_test/composition_section_negation_spec_setup.rb
@@ -17,7 +17,7 @@ RSpec.shared_context 'composition section negation check setup' do
 
       id test_id
 
-      run { warn_on_nilknown_empty_reason(%w[11450-4 48765-2 10160-0]) }
+      run { warn_on_nilknown_empty_reason(AUPSTestKit::BasicTestCompositionSectionReadModule::MANDATORY_SECTIONS_CODES) }
     end
 
     repo = Inferno::Repositories::Tests.new

--- a/spec/support/basic_test/composition_section_negation_spec_setup.rb
+++ b/spec/support/basic_test/composition_section_negation_spec_setup.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative 'composition_sections_fixture_support'
+require File.join(Gem::Specification.find_by_name('inferno_core').full_gem_path, 'spec/runnable_context')
+
+RSpec.shared_context 'composition section negation check setup' do
+  include_context 'when testing a runnable'
+  include_context 'composition sections check setup'
+  include CompositionSectionsFixtureSupport
+
+  let(:test) do
+    test_id = "#{suite_id}-nilknown_warning"
+    test_class = Class.new(Inferno::Test) do
+      include CompositionUtils
+      include AUPSTestKit::SectionNamesMapping
+      include AUPSTestKit::BasicTestCompositionSectionNegationModule
+
+      id test_id
+
+      run { warn_on_nilknown_empty_reason(%w[11450-4 48765-2 10160-0]) }
+    end
+
+    repo = Inferno::Repositories::Tests.new
+    repo.insert(test_class) unless repo.exists?(test_id)
+    test_class
+  end
+end

--- a/spec/unit/basic_test/composition_section_negation_spec.rb
+++ b/spec/unit/basic_test/composition_section_negation_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../../support/basic_test/composition_section_negation_spec_setup'
+
+RSpec.describe AUPSTestKit::BasicTestCompositionSectionNegationModule do
+  include_context 'composition section negation check setup'
+
+  describe 'warning against emptyReason=nilknown' do
+    it 'warns when a mandatory section uses emptyReason=nilknown instead of an explicit negation entry' do
+      outcome = run_with_fixture_bundle(test, fixture_filename: 'mandatory-nilknown-warning-bundle.json')
+
+      expect_pass(outcome)
+      expect_warning_message(
+        outcome,
+        msg(<<~MSG)
+          Patient Summary Allergies and Intolerances Section (48765-2) uses emptyReason = nilknown ('Nil Known'). AU PS prefers an explicit negation code on the section entry instead of Composition.section.emptyReason, e.g. AllergyIntolerance.code = 716186003 |No known allergy|.
+        MSG
+      )
+    end
+
+    it 'does not warn when sections are populated with entries as normal' do
+      outcome = run_with_fixture_bundle(test, fixture_filename: 'mandatory-success-bundle.json')
+
+      expect_pass(outcome)
+      expect(outcome[:messages]).to be_empty
+    end
+
+    it 'does not warn when emptyReason uses a legitimate code such as unavailable' do
+      outcome = run_with_fixture_bundle(test, fixture_filename: 'mandatory-unavailable-empty-reason-bundle.json')
+
+      expect_pass(outcome)
+      expect(outcome[:messages]).to be_empty
+    end
+
+    it 'does not warn when a section uses the preferred explicit negation code on its entry' do
+      outcome = run_with_fixture_bundle(test, fixture_filename: 'mandatory-negation-code-bundle.json')
+
+      expect_pass(outcome)
+      expect(outcome[:messages]).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Adds an advisory (warning-only) test that flags mandatory Patient Summary sections (Problems 11450-4, Allergies 48765-2, Medications 10160-0) that use Composition.section.emptyReason = nilknown instead of AU PS's preferred pattern of an explicit negation code on the section's entry resource. The new check is registered into all three suite variants (au_ps_bundle_instance, generate_au_ps_using_ips_summary_validation_tests, retrieve_au_ps_bundle_validation_tests), backed by a new shared module, three new fixture bundles, and unit tests.

Issue: https://github.com/hl7au/au-ps-inferno/issues/34
PR in the AU FHIR Inferno repo: https://github.com/hl7au/au-fhir-inferno/pull/189
Deployed preview instance: https://pr-189.preview.inferno.sparked-fhir.com
Example of the suite run: https://pr-189.preview.inferno.sparked-fhir.com/suites/au_ps_v100/aErWP9jiWsW/#1