### PR TITLE
Relax the inferno_core dependency to >= 1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Relax the `inferno_core` dependency from `~> 1.0.6` to `>= 1.0.6`. The tilde pin resolved to `>= 1.0.6, < 1.1.0` and was the only cap on `inferno_core` anywhere in the dependency tree, so it held every host application on 1.0.x. The kit uses only the public validation DSL (`resource_is_valid?`), which is unchanged through 1.4.x.
+
 ## [1.0.0] - 2026-07-29
 
 First stable release of the AU PS Inferno Test Kit, targeting AU PS Implementation Guide version 1.0.0. This release is functionally identical to 0.2.1; the version bump signals API and behaviour stability rather than new changes.

--- a/au_ps_inferno.gemspec
+++ b/au_ps_inferno.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'AU PS Inferno Test Kit'
   spec.homepage      = 'https://github.com/hl7au/au-ps-inferno'
   spec.license       = 'Apache-2.0'
-  spec.add_dependency 'inferno_core', '~> 1.0.6'
+  spec.add_dependency 'inferno_core', '>= 1.0.6'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'
   spec.add_development_dependency 'rspec', '~> 3.10'


### PR DESCRIPTION
## What

`au_ps_inferno.gemspec:14`, one character:

```diff
-  spec.add_dependency 'inferno_core', '~> 1.0.6'
+  spec.add_dependency 'inferno_core', '>= 1.0.6'
```

## Why

`~> 1.0.6` resolves to `>= 1.0.6, < 1.1.0`. Every other gem in the tree caps nothing:

| gem | constraint on `inferno_core` |
|---|---|
| `au_ps_inferno` 1.0.0 | `~> 1.0.6` |
| `au_core_test_kit` 1.4.4 | `>= 1.0.6` |
| `inferno_suite_generator` | `>= 1.0.6` |
| `validation_test_kit` 0.0.1 | `>= 0.4.2` |
| `smart_app_launch_test_kit` 0.4.6 | `>= 0.4.2` |
| `tls_test_kit` 0.2.3 | `>= 0.4.2` |

So this is the single constraint holding `inferno.hl7.org.au` on inferno_core 1.0.8 while upstream is at 1.4.2. It is not a soft preference: with this pin in place the platform's bundle does not resolve against 1.4.x at all, so no amount of work elsewhere unblocks the upgrade.

## Why it is safe

The reason inferno_core 1.1.0 broke other AU test kits is that it removed three `Validator` methods (inferno-framework/inferno-core#753). This kit never used them. Its only validation call is the public DSL:

```
lib/au_ps_inferno/utils/basic_test/bundle_module.rb:54
  resource_is_valid?(resource: resource, profile_url: profile_with_version)
```

whose signature is unchanged from 1.0.8 through 1.4.2 apart from two added keyword arguments with defaults. Comparing the two versions across the whole of inferno_core, `lib/inferno/dsl/fhir_resource_validation.rb` is the only file that loses any method, and no file is removed.

Verified by resolving and running the platform bundle against inferno_core 1.4.2 with this branch in place.

## Worth knowing

The kit's `BasicTest` inherits `resolve_path` from inferno_core's `FHIRResourceNavigation` (rather than shadowing it the way `au_core_test_kit` and `inferno_suite_generator` do), and that method's internals changed substantially between 1.0.8 and 1.4.2: choice elements (`value[x]`) now resolve instead of returning nothing, and path splitting handles quoted URLs inside `where(url='...')` instead of relying on a `(?<!hl7)\.` regex. Those are corrections rather than regressions, but they are the place to look if AU PS must-support results shift after a host application upgrades.

## Base

Branched from `v1.0.0` so the diff is exactly this line against the released gem. Needs a trivial forward-port to `master` and a 1.0.1 bump before release.

Refs hl7au/au-fhir-inferno#162