### PR TITLE
WIP: Integrate FHIRPath support for error tracing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,6 @@ group :development, :test do
 end
 
 gem 'fhir_packages_manager', '~> 0.3'
-gem 'inferno_suite_generator', github: 'hl7au/inferno_suite_generator', ref: '3d52a4d6adba85391f13676321a6c4ff587d2630'
+gem 'inferno_suite_generator', github: 'hl7au/inferno_suite_generator', ref: '446524abe9c0115221704b25fa6aceaab3c7b6a3'
 gem 'pg', '~> 1.5'
 gem 'rubocop', '~> 1.71.2'

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,6 @@ group :development, :test do
 end
 
 gem 'fhir_packages_manager', '~> 0.3'
-gem 'inferno_suite_generator', github: 'hl7au/inferno_suite_generator', branch: 'main'
+gem 'inferno_suite_generator', github: 'hl7au/inferno_suite_generator', ref: '3d52a4d6adba85391f13676321a6c4ff587d2630'
 gem 'pg', '~> 1.5'
 gem 'rubocop', '~> 1.71.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/hl7au/inferno_suite_generator.git
-  revision: f4c668d05c1da45ee14076b81634e89f255180b3
-  branch: main
+  revision: 3d52a4d6adba85391f13676321a6c4ff587d2630
+  ref: 3d52a4d6adba85391f13676321a6c4ff587d2630
   specs:
     inferno_suite_generator (0.1.0)
       deep_merge (~> 1.2, >= 1.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/hl7au/inferno_suite_generator.git
-  revision: 3d52a4d6adba85391f13676321a6c4ff587d2630
-  ref: 3d52a4d6adba85391f13676321a6c4ff587d2630
+  revision: 446524abe9c0115221704b25fa6aceaab3c7b6a3
+  ref: 446524abe9c0115221704b25fa6aceaab3c7b6a3
   specs:
     inferno_suite_generator (0.1.0)
       deep_merge (~> 1.2, >= 1.2.2)

--- a/compose.aidbox.yaml
+++ b/compose.aidbox.yaml
@@ -20,6 +20,7 @@ services:
       POSTGRES_DB: inferno
       POSTGRES_USER: postgres
       TX_SERVER_URL: https://tx.dev.hl7.org.au/fhir
+      INFERNO_HOST: http://localhost
   inferno-worker:
     build:
       context: ./
@@ -38,6 +39,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: inferno
       POSTGRES_USER: postgres
+      INFERNO_HOST: http://localhost
   validator-api-worker:
     image: ghcr.io/beda-software/aidbox-validator/aidbox-validator:main-891628f
     depends_on:

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,6 +17,7 @@ services:
       POSTGRES_DB: inferno
       POSTGRES_USER: postgres
       TX_SERVER_URL: https://tx.dev.hl7.org.au/fhir
+      INFERNO_HOST: http://localhost
   inferno-worker:
     build:
       context: ./
@@ -34,6 +35,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: inferno
       POSTGRES_USER: postgres
+      INFERNO_HOST: http://localhost
   validator-api:
     image: markiantorno/validator-wrapper:1.0.73
     environment:

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,23 +1,23 @@
 # this sets the user nginx will run as,
 #and the number of worker processes
 user nobody nogroup;
-worker_processes  2;
+worker_processes 2;
 #user www-data;
 #worker_processes auto;
 
 # setup where nginx will log errors to
 # and where the nginx process id resides
-error_log  /var/log/nginx/error.log;
-pid        /var/run/nginx.pid;
+error_log /var/log/nginx/error.log;
+pid /var/run/nginx.pid;
 
 events {
-  worker_connections  1024;
+  worker_connections 1024;
   # set to on if you have more than 1 worker_processes
   accept_mutex on;
 }
 
 http {
-  include       /etc/nginx/mime.types;
+  include /etc/nginx/mime.types;
 
   default_type application/octet-stream;
   access_log /tmp/nginx.access.log combined;
@@ -25,20 +25,20 @@ http {
   # use the kernel sendfile
   # sendfile        on;  # this causes over-caching because modified timestamps lost in VM
   # prepend http headers before sendfile()
-  tcp_nopush     on;
+  tcp_nopush on;
 
-  keepalive_timeout  600;
-  tcp_nodelay        on;
+  keepalive_timeout 600;
+  tcp_nodelay on;
 
-  gzip  on;
+  gzip on;
   gzip_vary on;
   gzip_min_length 500;
 
   gzip_disable "MSIE [1-6]\.(?!.*SV1)";
   gzip_types text/plain text/xml text/css
-     text/comma-separated-values
-     text/javascript application/x-javascript
-     application/atom+xml image/x-icon;
+  text/comma-separated-values
+  text/javascript application/x-javascript
+  application/atom+xml image/x-icon;
 
   # configure the virtual host
   server {
@@ -82,6 +82,34 @@ http {
       proxy_read_timeout 600s;
 
       proxy_pass http://validator-api:3500/;
+    }
+
+    location ~ ^/custom/[^/]+/resources/ {
+      # FHIRPath Lab (https://fhirpath-lab.com) fetches these resource-keeper
+      # URLs directly from the browser to evaluate a failing FHIRPath
+      # expression against the real resource. Its request carries a
+      # Cache-Control header, which forces a CORS preflight; without these
+      # headers the browser blocks the request before it ever reaches Inferno.
+      add_header Access-Control-Allow-Origin "https://fhirpath-lab.com" always;
+      add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
+      add_header Access-Control-Allow-Headers "cache-control, content-type, accept" always;
+
+      if ($request_method = OPTIONS) {
+        return 204;
+      }
+
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
+      proxy_redirect off;
+      proxy_set_header Connection '';
+      proxy_http_version 1.1;
+      chunked_transfer_encoding off;
+      proxy_buffering off;
+      proxy_cache off;
+
+      proxy_pass http://inferno:4567;
     }
   }
 }

--- a/lib/au_ps_inferno/suite/au_ps_v100.rb
+++ b/lib/au_ps_inferno/suite/au_ps_v100.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'inferno_suite_generator/utils/fhirpath_lab_message_linker'
+
+require 'inferno_suite_generator/utils/resource_keeper_endpoints'
+
 require_relative '../version'
 
 require_relative 'au_ps_bundle_instance/au_ps_bundle_instance'
@@ -9,6 +13,7 @@ require_relative 'au_ps_retrieve_cs_group/au_ps_retrieve_cs_group'
 require_relative 'retrieve_au_ps_bundle_validation_tests/retrieve_au_ps_bundle_validation_tests'
 
 require_relative 'generate_au_ps_using_ips_summary_validation_tests/generate_au_ps_using_ips_summary_validation_tests'
+
 
 module AUPSTestKit
   # Test suite for the AU PS (Australian Primary Care and Shared Health) Implementation Guide.
@@ -39,6 +44,15 @@ module AUPSTestKit
         noEcosystem true
       end
     end
+
+    FHIRPATHLAB_URL = ENV.fetch('FHIRPATHLAB_URL', 'https://fhirpath-lab.com/FhirPath').presence
+
+    suite_endpoint :post, '/resources/:session_id/:resource_type/:resource_id',
+                   InfernoSuiteGenerator::SaveResourceEndpoint
+    suite_endpoint :get, '/resources/:session_id/:resource_type/:resource_id',
+                   InfernoSuiteGenerator::FetchResourceEndpoint
+    suite_endpoint :delete, '/resources/:session_id',
+                   InfernoSuiteGenerator::DeleteSessionResourcesEndpoint
 
     group from: :suite_au_ps_bundle_instance
 

--- a/lib/au_ps_inferno/suite/au_ps_v100.rb
+++ b/lib/au_ps_inferno/suite/au_ps_v100.rb
@@ -47,8 +47,6 @@ module AUPSTestKit
 
     FHIRPATHLAB_URL = ENV.fetch('FHIRPATHLAB_URL', 'https://fhirpath-lab.com/FhirPath').presence
 
-    suite_endpoint :post, '/resources/:session_id/:resource_type/:resource_id',
-                   InfernoSuiteGenerator::SaveResourceEndpoint
     suite_endpoint :get, '/resources/:session_id/:resource_type/:resource_id',
                    InfernoSuiteGenerator::FetchResourceEndpoint
     suite_endpoint :delete, '/resources/:session_id',

--- a/lib/au_ps_inferno/utils/composition_utils.rb
+++ b/lib/au_ps_inferno/utils/composition_utils.rb
@@ -2,6 +2,7 @@
 
 require_relative 'bundle_decorator'
 require_relative 'composition_utils/boolean_and_stats'
+require 'inferno_suite_generator/utils/kept_resources_repository'
 
 # Utilities for FHIR Composition resources
 module CompositionUtils
@@ -30,6 +31,7 @@ module CompositionUtils
 
   def save_bundle_to_scratch(bundle)
     scratch[bundle_scratch_key] = bundle
+    InfernoSuiteGenerator::KeptResourcesRepository.new.save(session_id: test_session_id, resource: bundle)
   end
 
   def omit_unless_bundle_in_scratch


### PR DESCRIPTION
Wires the AU PS suite up to [FHIRPath Lab](https://fhirpath-lab.com/) so that FHIRPath assertion failures can be opened directly in FHIRPath Lab's debugger against the actual resource that failed, instead of requiring manual copy/paste.